### PR TITLE
HAWKULAR-25: Add 'hawtio-template-cache' as bower dependency

### DIFF
--- a/ui/console/bower.json
+++ b/ui/console/bower.json
@@ -15,6 +15,7 @@
     "hawtio-core": "2.0.9",
     "hawtio-core-navigation": "2.0.17",
     "hawtio-utilities": "2.0.16",
+    "hawtio-template-cache": "2.0.1",
     "hawkular-ui-components": "~0.1.8"
   },
   "devDependencies": {

--- a/ui/console/index.html
+++ b/ui/console/index.html
@@ -41,6 +41,7 @@
     <script src="libs/hawtio-utilities/dist/sugar.js"></script>
     <script src="libs/hawtio-utilities/dist/angular-file-upload.js"></script>
     <script src="libs/hawtio-utilities/dist/hawtio-utilities.js"></script>
+    <script src="libs/hawtio-template-cache/dist/hawtio-template-cache.js"></script>
     <script src="libs/hawkular-ui-components/dist/hawkular-metrics.js"></script>
     <script src="libs/hawkular-ui-components/dist/hawkular-alerts.js"></script>
     <!-- endbower -->


### PR DESCRIPTION
Fixes fetching templates from $templateCache which may cause issues if they are not there yet.