### PR TITLE
When a destination is added, immediately ping it, so first result is in quicker

### DIFF
--- a/modules/pinger/src/main/java/org/hawkular/component/pinger/PingManager.java
+++ b/modules/pinger/src/main/java/org/hawkular/component/pinger/PingManager.java
@@ -100,6 +100,14 @@ public class PingManager {
             return;
         }
 
+        doThePing(destinations);
+    }
+
+    /**
+     * Runs the pinging work on the provided list of destinations
+     * @param destinations Set of destinations to ping
+     */
+    private void doThePing(Set<PingDestination> destinations) {
         List<PingStatus> results = new ArrayList<>(destinations.size());
         List<Future<PingStatus>> futures = new ArrayList<>(destinations.size());
 
@@ -107,7 +115,6 @@ public class PingManager {
             Future<PingStatus> result = pinger.ping(destination);
             futures.add(result);
         }
-
 
 
         int round = 1;
@@ -198,8 +205,16 @@ public class PingManager {
         mMetrics.add(outer);
     }
 
-    public void addDestination(PingDestination s) {
-        destinations.add(s);
+    /**
+     * Add a new destination into the system. This triggers an immediate
+     * ping and then adding to the list of destinations.
+     * @param pd new Destination
+     */
+    public void addDestination(PingDestination pd) {
+        Set<PingDestination> oneTimeDestinations = new HashSet<>(1);
+        oneTimeDestinations.add(pd);
+        doThePing(oneTimeDestinations);
+        destinations.add(pd);
     }
 
     public List<PingDestination> getDestinations() {

--- a/modules/pinger/src/test/java/org/hawkular/component/pinger/test/PingerTest.java
+++ b/modules/pinger/src/test/java/org/hawkular/component/pinger/test/PingerTest.java
@@ -21,9 +21,11 @@ import org.hawkular.component.pinger.PingDestination;
 import org.hawkular.component.pinger.PingManager;
 import org.hawkular.component.pinger.PingStatus;
 import org.hawkular.component.pinger.Pinger;
+import org.hawkular.metrics.client.common.SingleMetric;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Simple test for the pinger
@@ -49,6 +51,7 @@ public class PingerTest {
 
         PingManager manager = new PingManager();
         manager.pinger = new Pinger();
+        manager.metricPublisher = new NoOpMetricPublisher();
         PingDestination destination = new PingDestination("123","http://hawkular.github.io");
         manager.addDestination(destination);
         manager.metricPublisher = new MetricPublisher();
@@ -65,14 +68,31 @@ public class PingerTest {
      * running inventory instance
      * @throws Exception
      */
-//    @Test
+    @Test
     public void testPingManagerStartup() throws Exception {
 
         PingManager manager = new PingManager();
-        manager.startUp();
+        try {
+            manager.startUp();
+        } catch (javax.ws.rs.ProcessingException e) {
+            // It's ok, as we may not have the full Jax-RS client stack available
+        }
         List<PingDestination> destinations = manager.getDestinations();
         manager.pinger = new Pinger();
         manager.scheduleWork();
 
+    }
+
+
+    private class NoOpMetricPublisher extends MetricPublisher {
+        @Override
+        public void sendToMetricsViaRest(String tenantId, List<Map<String, Object>> metrics) {
+
+        }
+
+        @Override
+        public void publishToTopic(String tenantId, List<SingleMetric> metrics) {
+
+        }
     }
 }


### PR DESCRIPTION
Small refactoring to start a ping on destination add.
This has the benefit that a UI user may enter the URL and then switch to the graphs and with some luck already see some data.