### PR TITLE
Got rid of node.js warnings

### DIFF
--- a/ui/console/src/main/scripts/gulpfile.js
+++ b/ui/console/src/main/scripts/gulpfile.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 var gulp = require('gulp'),
+    del = require('del'),
     wiredep = require('wiredep').stream,
     eventStream = require('event-stream'),
     gulpLoadPlugins = require('gulp-load-plugins'),
@@ -68,8 +69,7 @@ gulp.task('path-adjust', function () {
 });
 
 gulp.task('clean-defs', function () {
-    return gulp.src('defs.d.ts', {read: false})
-        .pipe(plugins.clean());
+    del(['defs.d.ts/**']);
 });
 
 gulp.task('tsc', ['clean-defs'], function () {
@@ -134,8 +134,7 @@ gulp.task('concat', ['template'], function () {
 });
 
 gulp.task('clean', ['concat'], function () {
-    return gulp.src(['templates.js', 'compiled.js'], {read: false})
-        .pipe(plugins.clean());
+    del(['templates.js', 'compiled.js']);
 });
 
 gulp.task('watch', ['build'], function () {

--- a/ui/console/src/main/scripts/package.json
+++ b/ui/console/src/main/scripts/package.json
@@ -1,12 +1,13 @@
 {
   "name": "hawkular-console",
   "version": "0.1.0",
+  "private": true,
   "devDependencies": {
     "bower": "^1.3.12",
+    "del": "1.1.1",
     "event-stream": "^3.1.7",
     "gulp": "^3.8.10",
     "gulp-angular-templatecache": "^1.5.0",
-    "gulp-clean": "^0.3.1",
     "gulp-concat": "^2.4.2",
     "gulp-connect": "^2.2.0",
     "gulp-load-plugins": "^0.8.0",


### PR DESCRIPTION
* Gulp-clean is deprecated, using del is suggested.
* Non-private packages should have several properties in package.json like git-repo, etc.