### PR TITLE
Added integration with hawkular accounts

### DIFF
--- a/kettle/pom.xml
+++ b/kettle/pom.xml
@@ -43,6 +43,8 @@
     <version.org.hawkular.alerts>1.0.0-SNAPSHOT</version.org.hawkular.alerts>
     <version.org.hawkular.metrics>0.3.0-SNAPSHOT</version.org.hawkular.metrics>
     <version.org.hawkular.console>1.0.0-SNAPSHOT</version.org.hawkular.console>
+    <version.org.hawkular.accounts>1.0.0-SNAPSHOT</version.org.hawkular.accounts>
+    <version.org.keycloak>1.1.0.Final</version.org.keycloak>
   </properties>
 
   <dependencies>
@@ -101,6 +103,21 @@
       <version>${version.org.hawkular.console}</version>
       <type>war</type>
     </dependency>
+    <dependency>
+      <groupId>org.hawkular.accounts</groupId>
+      <artifactId>hawkular-accounts</artifactId>
+      <version>${version.org.hawkular.accounts}</version>
+      <type>war</type>
+    </dependency>
+
+    <!-- Keycloak-related dependencies -->
+    <dependency>
+      <groupId>org.keycloak</groupId>
+      <artifactId>keycloak-wildfly-adapter-dist</artifactId>
+      <version>${version.org.keycloak}</version>
+      <type>zip</type>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -215,6 +232,32 @@
           </resources>
         </configuration>
       </plugin>
+
+      <!-- Generate some keys for Keycloak integration, so that we don't ship with default credentials -->
+      <plugin>
+        <groupId>org.codehaus.gmaven</groupId>
+        <artifactId>gmaven-plugin</artifactId>
+        <version>1.3</version>
+        <executions>
+          <execution>
+            <id>set-custom-property</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+            <configuration>
+              <source>
+                import java.util.UUID
+                def uuidBackend = UUID.randomUUID().toString()
+                def uuidUi = UUID.randomUUID().toString()
+                project.properties.setProperty('uuid.hawkular.accounts.backend', uuidBackend.toString())
+                project.properties.setProperty('uuid.hawkular.accounts.ui', uuidUi.toString())
+              </source>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/kettle/src/main/resources/bin/standalone.conf
+++ b/kettle/src/main/resources/bin/standalone.conf
@@ -1,0 +1,90 @@
+#
+# Copyright 2015 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+## -*- shell-script -*- ######################################################
+##                                                                          ##
+##  JBoss Bootstrap Script Configuration                                    ##
+##                                                                          ##
+##############################################################################
+
+#
+# This file is optional; it may be removed if not needed.
+#
+
+#
+# Specify the maximum file descriptor limit, use "max" or "maximum" to use
+# the default, as queried by the system.
+#
+# Defaults to "maximum"
+#
+#MAX_FD="maximum"
+
+#
+# Specify the profiler configuration file to load.
+#
+# Default is to not load profiler configuration file.
+#
+#PROFILER=""
+
+#
+# Specify the location of the Java home directory.  If set then $JAVA will
+# be defined to $JAVA_HOME/bin/java, else $JAVA will be "java".
+#
+#JAVA_HOME="/opt/java/jdk"
+
+#
+# Specify the exact Java VM executable to use.
+#
+#JAVA=""
+
+if [ "x$JBOSS_MODULES_SYSTEM_PKGS" = "x" ]; then
+   JBOSS_MODULES_SYSTEM_PKGS="org.jboss.byteman"
+fi
+
+# Uncomment the following line to prevent manipulation of JVM options
+# by shell scripts.
+#
+#PRESERVE_JAVA_OPTS=true
+
+#
+# Specify options to pass to the Java VM.
+#
+if [ "x$JAVA_OPTS" = "x" ]; then
+   JAVA_OPTS="-Xms64m -Xmx512m -XX:MaxPermSize=256m -Djava.net.preferIPv4Stack=true"
+   JAVA_OPTS="$JAVA_OPTS -Djboss.modules.system.pkgs=$JBOSS_MODULES_SYSTEM_PKGS -Djava.awt.headless=true"
+else
+   echo "JAVA_OPTS already set in environment; overriding default settings with values: $JAVA_OPTS"
+fi
+
+# Sample JPDA settings for remote socket debugging
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
+
+# Sample JPDA settings for shared memory debugging
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_shmem,server=y,suspend=n,address=jboss"
+
+# Uncomment to not use JBoss Modules lockless mode
+#JAVA_OPTS="$JAVA_OPTS -Djboss.modules.lockless=false"
+
+# Uncomment to gather JBoss Modules metrics
+#JAVA_OPTS="$JAVA_OPTS -Djboss.modules.metrics=true"
+
+# Uncomment this in order to be able to run WildFly on FreeBSD
+# when you get "epoll_create function not implemented" message in dmesg output
+#JAVA_OPTS="$JAVA_OPTS -Djava.nio.channels.spi.SelectorProvider=sun.nio.ch.PollSelectorProvider"
+
+# Import our realm into Keycloak
+JAVA_OPTS="$JAVA_OPTS -Dkeycloak.import=${JBOSS_HOME}/standalone/configuration/hawkular-realm.json"

--- a/kettle/src/main/resources/standalone/configuration/hawkular-realm.json
+++ b/kettle/src/main/resources/standalone/configuration/hawkular-realm.json
@@ -1,0 +1,81 @@
+{
+  "id" : "hawkular-realm",
+  "realm" : "hawkular",
+  "enabled" : true,
+  "sslRequired" : "none",
+  "passwordCredentialGrantAllowed" : true,
+  "registrationAllowed" : true,
+  "requiredCredentials" : [ "password" ],
+  "defaultRoles" : [ "user" ],
+  "roles" : {
+    "realm" : [
+      {
+        "name": "user",
+        "description": "User privileges",
+        "composite": true,
+        "composites": {
+          "application": {
+            "hawkular-accounts-backend": ["user"]
+          }
+        }
+      },
+      {
+        "name": "admin",
+        "description": "Admin privileges",
+        "composite": true,
+        "composites": {
+          "application": {
+            "hawkular-accounts-backend": ["admin"]
+          },
+          "realm": ["user"]
+        }
+      }
+    ],
+    "application": {
+      "hawkular-accounts-backend": [
+        {
+          "name": "user"
+        },
+        {
+          "name": "admin"
+        }
+      ]
+    }
+  },
+  "scopeMappings": [
+    {
+      "client": "hawkular-accounts-ui",
+      "roles": ["user"]
+    }
+  ],
+  "applications" : [
+    {
+      "name": "hawkular-accounts-backend",
+      "enabled": true,
+      "bearerOnly" : true,
+      "publicClient": false,
+      "secret" : "${uuid.hawkular.accounts.backend}"
+    },
+    {
+      "name": "hawkular-accounts-ui",
+      "enabled": true,
+      "bearerOnly" : false,
+      "publicClient": true,
+      "secret": "${uuid.hawkular.accounts.ui}",
+      "fullScopeAllowed" : false,
+      "redirectUris": [
+        "http://localhost:9000/*",
+        "http://localhost:2772/*"
+      ],
+      "webOrigins": [
+        "http://localhost:9000",
+        "http://localhost:2772"
+      ],
+      "claims": {
+        "username": true,
+        "name": true,
+        "email": true
+      }
+    }
+  ]
+}

--- a/kettle/src/main/scripts/distro-assembly.xml
+++ b/kettle/src/main/scripts/distro-assembly.xml
@@ -35,6 +35,10 @@
       <fileMode>0644</fileMode>
       <directoryMode>0755</directoryMode>
     </fileSet>
+    <fileSet>
+      <directory>src/main/resources</directory>
+      <outputDirectory>/${nest.dist.zip.root.dir}/</outputDirectory>
+    </fileSet>
   </fileSets>
 
   <dependencySets>
@@ -49,6 +53,10 @@
         <!-- exclude unwanted stuff and exclude stuff we want to overlay via our own distro-resources -->
         <excludes>
           <exclude>${nest.dist.zip.root.dir}/standalone/configuration/standalone.xml</exclude>
+
+          <!-- Our standalone.conf contains an override to the JAVA_OPTS, to tell Keycloak to import our realm -->
+          <exclude>${nest.dist.zip.root.dir}/bin/standalone.conf</exclude>
+
         </excludes>
       </unpackOptions>
     </dependencySet>
@@ -71,7 +79,43 @@
       <directoryMode>0755</directoryMode>
     </dependencySet>
 
+    <!--
+    hawkular-accounts is separated from the others because we need a stable name to the war, without the
+    version number. This is because we use the Keycloak's "secure-deployment" to configure the integration, and that
+    requires the war name.
+    -->
+    <dependencySet>
+      <outputDirectory>${nest.dist.zip.root.dir}/modules/system/layers/base/org/hawkular/nest/main/deployments</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <includes>
+        <include>org.hawkular.accounts:hawkular-accounts:war</include>
+      </includes>
+      <outputFileNameMapping>hawkular-accounts.war</outputFileNameMapping>
+      <unpack>false</unpack>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+    </dependencySet>
+
+    <!-- Keycloak modules -->
+    <dependencySet>
+      <outputDirectory>${nest.dist.zip.root.dir}/</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <includes>
+        <include>org.keycloak:keycloak-wildfly-adapter-dist:zip</include>
+      </includes>
+      <unpack>true</unpack>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+    </dependencySet>
   </dependencySets>
+
+  <files>
+    <file>
+      <source>src/main/resources/standalone/configuration/hawkular-realm.json</source>
+      <outputDirectory>${nest.dist.zip.root.dir}/standalone/configuration/</outputDirectory>
+      <filtered>true</filtered>
+    </file>
+  </files>
 
 </assembly>
 

--- a/kettle/src/main/scripts/standalone.xsl
+++ b/kettle/src/main/scripts/standalone.xsl
@@ -40,9 +40,63 @@
   <xsl:template match="node()[name(.)='extensions']">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
+      <extension module="org.keycloak.keycloak-subsystem"/>
     </xsl:copy>
     <xsl:call-template name="system-properties"/>
   </xsl:template>
+
+  <!-- Keycloak-related - datasource, our secured deployments (important) and security domain definitions -->
+  <xsl:template match="node()[name(.)='datasources']">
+    <xsl:copy>
+      <xsl:apply-templates select="node()[name(.)='datasource']"/>
+      <datasource jndi-name="java:jboss/datasources/KeycloakDS" pool-name="KeycloakDS" enabled="true" use-java-context="true">
+        <connection-url>jdbc:h2:${jboss.server.data.dir}${/}h2${/}keycloak;AUTO_SERVER=TRUE</connection-url>
+        <driver>h2</driver>
+        <security>
+          <user-name>sa</user-name>
+          <password>sa</password>
+        </security>
+      </datasource>
+      <xsl:apply-templates select="node()[name(.)='drivers']"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()[name(.)='profile']">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+      <subsystem xmlns="urn:jboss:domain:keycloak:1.0">
+        <auth-server name="main-auth-server">
+          <enabled>true</enabled>
+          <web-context>auth</web-context>
+        </auth-server>
+        <realm name="hawkular">
+          <auth-server-url>http://localhost:8080/auth</auth-server-url>
+          <ssl-required>none</ssl-required>
+        </realm>
+        <secure-deployment name="hawkular-accounts.war">
+          <realm>hawkular</realm>
+          <resource>hawkular-accounts-backend</resource>
+          <use-resource-role-mappings>true</use-resource-role-mappings>
+          <enable-cors>true</enable-cors>
+        </secure-deployment>
+      </subsystem>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()[name(.)='security-domains']">
+    <xsl:copy>
+      <xsl:apply-templates select="node()[name(.)='security-domain']"/>
+      <security-domain name="keycloak">
+        <authentication>
+          <login-module code="org.keycloak.adapters.jboss.KeycloakLoginModule" flag="required"/>
+        </authentication>
+      </security-domain>
+      <security-domain name="sp" cache-type="default">
+        <authentication>
+          <login-module code="org.picketlink.identity.federation.bindings.wildfly.SAML2LoginModule" flag="required"/>
+        </authentication>
+      </security-domain>
+    </xsl:copy>
+  </xsl:template>
+  <!-- End of Keycloak-related changes -->
 
   <!-- add our JMS queues/topices that are required to be defined as admin-objects -->
   <xsl:template name="admin-objects">


### PR DESCRIPTION
This PR integrates Hawkular Accounts backend into Kettle. The change itself should not be invasive, except for the fact that a `standalone.conf` is to be shipped with it. It is required as we need to add a property to the command line specifying which realm Keycloak should import at boot.