### PR TITLE
Bower Resolutions are required in ui console 

### DIFF
--- a/ui/console/src/main/scripts/bower.json
+++ b/ui/console/src/main/scripts/bower.json
@@ -21,5 +21,9 @@
   },
   "devDependencies": {
     "hawtio-core-dts": "2.0.16"
+  },
+  "resolutions": {
+    "patternfly": "1.1.3",
+    "angular": "1.3.15"
   }
 }


### PR DESCRIPTION
to match those from hawkular-ui-console alert changes.