### PR TITLE
Updating maven build profiles

### DIFF
--- a/ui/README.adoc
+++ b/ui/README.adoc
@@ -23,15 +23,14 @@ http://nodejs.org/[Node.js] and its related modules are managed by the https://g
 They are downloaded to the build target (./console/target) directory, where the actual http://gulpjs.com/[Gulp] based build process
 (triggered by the maven plugin) happens.
 
-To save some time during the build process, the downloaded http://nodejs.org/[Node.js] files and its related modules are not deleted after the
+To save some time during the build process, the downloaded http://nodejs.org/[Node.js] files and its related modules
+don't have to be deleted after invoking the `clean` target. If you want to persist the node.js related stuff in the target
+directory, please use the `cache` profile:
 
-`mvn clean`
+`mvn clean -Pcache`
 
-is executed. If you want to delete the whole target directory, please use the `release` profile:
-
-`mvn clean -Prelease`
-
-In that case, the http://nodejs.org/[Node.js] is downloaded again, together with relevant modules.
+In that case, the http://nodejs.org/[Node.js] is not deleted and doesn't have to be downloaded again, together with
+npm modules and bower packages. Be aware, this causes the libraries not being updated.
 
 After the console is built, you can access it by traversing to the the build target (./console/target/gulp-build) directory:
 

--- a/ui/README.adoc
+++ b/ui/README.adoc
@@ -46,6 +46,18 @@ it's only a front-end and you need the server running for console to work proper
 that is scans for file changes in the source directory and apply them directly into the target directory, which is
 suitable for console developing since it doesn't require the whole maven build to see the actual changes in the console UI.
 
+== Hawkular-ui-components development
+
+If you want to use your local version of hawkular-ui-components, you can use the `link` profile and the
+https://oncletom.io/2013/live-development-bower-component/[bower link functionality]. In the hawkular-ui-components,
+link your bower package with:
+
+`bower link`
+
+and then build the kettle with:
+
+`mvn clean install -Plink`
+
 == Dev Install
 
 You can still re-build the console using only java-script based tools. Please do that only after maven build and

--- a/ui/console/pom.xml
+++ b/ui/console/pom.xml
@@ -173,7 +173,7 @@
 
   <profiles>
     <profile>
-      <id>dev</id>
+      <id>cache</id>
       <properties>
         <hawkular.console.context>/</hawkular.console.context>
         <hawkular.console.index.html.base.href>/</hawkular.console.index.html.base.href>

--- a/ui/console/pom.xml
+++ b/ui/console/pom.xml
@@ -156,6 +156,12 @@
                 <include>libs/**</include>
                 <include>dist/**</include>
               </includes>
+              <excludes>
+                <exclude>node_modules/**</exclude>
+                <exclude>.bower/**</exclude>
+                <exclude>node/**</exclude>
+                <exclude>libs/hawkular-ui-components/node_modules/**</exclude>
+              </excludes>
               <filtering>false</filtering>
             </resource>
           </webResources>
@@ -190,6 +196,74 @@
                 </fileset>
               </filesets>
             </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>link</id>
+      <properties>
+        <hawkular.console.context>/</hawkular.console.context>
+        <hawkular.console.index.html.base.href>/</hawkular.console.index.html.base.href>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <version>0.0.20</version>
+
+            <configuration>
+              <workingDirectory>target/gulp-build/</workingDirectory>
+            </configuration>
+
+            <executions>
+              <execution>
+                <id>install node and npm</id>
+                <goals>
+                  <goal>install-node-and-npm</goal>
+                </goals>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <nodeVersion>v0.10.33</nodeVersion>
+                  <npmVersion>2.1.10</npmVersion>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>npm install</id>
+                <goals>
+                  <goal>npm</goal>
+                </goals>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <arguments>install</arguments>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>bower link</id>
+                <goals>
+                  <goal>bower</goal>
+                </goals>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <arguments>link hawkular-ui-components</arguments>
+                </configuration>
+              </execution>
+
+              <execution>
+                <id>gulp build</id>
+                <goals>
+                  <goal>gulp</goal>
+                </goals>
+                <phase>prepare-package</phase>
+                <configuration>
+                  <arguments>build</arguments>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Profiles add/changed:
* -Plink: Is using bower link functionality for linking the local hawkular-ui-components bower package.
* -Pcache: Was the `dev` profile before. It's used to persist (not download) node.js related stuff (npm/bower packages). The profile was renamed so it doesn't interfere with the `dev` profile anymore which has much broader functionality (creating user, etc) these days.