### PR TITLE
Support maven 3.3.1

### DIFF
--- a/ui/console/pom.xml
+++ b/ui/console/pom.xml
@@ -84,7 +84,7 @@
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
-        <version>0.0.20</version>
+        <version>0.0.23</version>
 
         <configuration>
           <workingDirectory>target/gulp-build/</workingDirectory>


### PR DESCRIPTION
Frontend-maven-plugin doesn't work with Maven 3.3.1 before version 0.0.23.