### PR TITLE
HAWKULAR-193 Upgrade frontend-maven-plugin version to fix 'missing cl…

### DIFF
--- a/ui/console/pom.xml
+++ b/ui/console/pom.xml
@@ -158,7 +158,7 @@
           <plugin>
             <groupId>com.github.eirslett</groupId>
             <artifactId>frontend-maven-plugin</artifactId>
-            <version>0.0.20</version>
+            <version>0.0.23</version>
 
             <configuration>
               <workingDirectory>target/gulp-build/</workingDirectory>


### PR DESCRIPTION
…ass' error when installing npm