### PR TITLE
Pinger fixes:

### DIFF
--- a/modules/pinger/pom.xml
+++ b/modules/pinger/pom.xml
@@ -62,12 +62,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hawkular.inventory</groupId>
-      <artifactId>hawkular-inventory-cdi</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.hawkular.metrics</groupId>
       <artifactId>clients-common</artifactId>
     </dependency>
@@ -96,6 +90,7 @@
       <version>1.1-rev-1</version> <!-- TODO move to parent -->
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>


### PR DESCRIPTION
* use JNDI instead of CDI for inventory injection to prevent initialization
errors (kudos to jpkroehling for suggesting that)
* fix resource update when publishing traits

This depends on https://github.com/hawkular/hawkular-inventory/pull/69.

With both the inventory fixes and this PR in, it is possible to add URLs and monitor them successfully. Delete is still broken and will have to be fixed on the inventory side in a separate PR (there's non-trivial amount of work needed to make it work correctly).