### PR TITLE
Add template realm as optional

### DIFF
--- a/dist/assembly.xml
+++ b/dist/assembly.xml
@@ -180,6 +180,12 @@
       <filtered>true</filtered>
       <destName>hawkular-realm.json</destName>
     </file>
+    <file>
+      <source>src/main/resources/configuration/hawkular-realm-for-dev.json</source>
+      <outputDirectory>${wildfly.dist.zip.root.dir}/standalone/configuration/</outputDirectory>
+      <filtered>true</filtered>
+      <destName>hawkular-realm-for-dev.json</destName>
+    </file>
   </files>
 
 </assembly>


### PR DESCRIPTION
Adding hawkular-realm-for-dev.json in the hawkular-dist as optional file makes easy to populate a demo user when using the hawkular-dist from nexus.
If not, a pre-process to get the UUID is needed and makes things more difficult to start using hawkular from a pom.xml