### PR TITLE
HAWKULAR-249 Use a relative resource for auth 

### DIFF
--- a/dist/docker/README.adoc
+++ b/dist/docker/README.adoc
@@ -1,5 +1,5 @@
 == Build the Kettle Docker image
-Make sure you are in hawkular/kettle directory
+Make sure you are in hawkular/dist directory
 [source,shell]
 ----
 mvn package docker:build

--- a/dist/src/main/resources/wildfly/patches/standalone.xsl
+++ b/dist/src/main/resources/wildfly/patches/standalone.xsl
@@ -308,7 +308,8 @@
           <web-context>auth</web-context>
         </auth-server>
         <realm name="hawkular">
-          <auth-server-url>http://localhost:8080/auth</auth-server-url>
+          <auth-server-url>/auth</auth-server-url>
+          <auth-server-url-for-backend-requests>http://localhost:8080/auth</auth-server-url-for-backend-requests>
           <ssl-required>none</ssl-required>
         </realm>
         <secure-deployment name="hawkular-accounts.war">


### PR DESCRIPTION
and the fixed one for the server->KC requests.
This is to fix running Hawkular inside Docker, where the IP / port of the docker container is different than localhost:8080. 