### PR TITLE
move to agent 0.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <version.gnu.getopt>1.0.13</version.gnu.getopt>
     <version.org.apache.activemq>5.10.0</version.org.apache.activemq>
     <version.org.hawkular.accounts>1.0.3</version.org.hawkular.accounts>
-    <version.org.hawkular.agent>0.0.5</version.org.hawkular.agent>
+    <version.org.hawkular.agent>0.0.6</version.org.hawkular.agent>
     <version.org.hawkular.alerts>1.0.0-SNAPSHOT</version.org.hawkular.alerts>
     <version.org.hawkular.availCreator>${project.version}</version.org.hawkular.availCreator>
     <version.org.hawkular.bus>0.0.6</version.org.hawkular.bus>


### PR DESCRIPTION
the UI needs to know what display name to show for resources. this moves the agent to 0.0.6 which will add a name property to all resources so the UI can refer to them