### PR TITLE
Upgrade metrics to 0.3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <version.org.hawkular.bus>0.0.6</version.org.hawkular.bus>
     <version.org.hawkular.console>1.0.0-SNAPSHOT</version.org.hawkular.console>
     <version.org.hawkular.inventory>0.0.7</version.org.hawkular.inventory>
-    <version.org.hawkular.metrics>0.3.2-SNAPSHOT</version.org.hawkular.metrics>
+    <version.org.hawkular.metrics>0.3.4</version.org.hawkular.metrics>
     <version.org.hawkular.nest>0.0.6</version.org.hawkular.nest>
     <version.org.hawkular.pinger>${project.version}</version.org.hawkular.pinger>
     <version.org.keycloak>1.2.0.Final</version.org.keycloak>


### PR DESCRIPTION
The first step towards having metrics 0.3.4. The tests are expected to fail.