### PR TITLE
HAWKULAR-285 bump up to agent 0.0.7 so we can get host/port informati…

### DIFF
--- a/dist/src/main/resources/wildfly/patches/standalone.xsl
+++ b/dist/src/main/resources/wildfly/patches/standalone.xsl
@@ -321,7 +321,6 @@
               <xsl:attribute name="password">SET_ME</xsl:attribute>
             </xsl:otherwise>
           </xsl:choose>
-          <xsl:attribute name="url">http://&#36;{jboss.bind.address:127.0.0.1}:&#36;{jboss.http.port:8080}</xsl:attribute>
         </storage-adapter>
 
         <metric-set-dmr name="WildFly Memory Metrics" enabled="true">

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <version.gnu.getopt>1.0.13</version.gnu.getopt>
     <version.org.apache.activemq>5.10.0</version.org.apache.activemq>
     <version.org.hawkular.accounts>1.0.3</version.org.hawkular.accounts>
-    <version.org.hawkular.agent>0.0.6</version.org.hawkular.agent>
+    <version.org.hawkular.agent>0.0.7</version.org.hawkular.agent>
     <version.org.hawkular.alerts>1.0.0-SNAPSHOT</version.org.hawkular.alerts>
     <version.org.hawkular.availCreator>${project.version}</version.org.hawkular.availCreator>
     <version.org.hawkular.bus>0.0.6</version.org.hawkular.bus>


### PR DESCRIPTION
…on from WildFly the "official" way - this allows the agent to understand port offsets