### PR TITLE
HAWKULAR-329: 'miliseconds' spelled wrong

### DIFF
--- a/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/html/alerts-setup.html
+++ b/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/html/alerts-setup.html
@@ -43,7 +43,7 @@
             <div class="input-group input-addon">
               <input type="number" class="form-control" placeholder="Time" id="time"
                      ng-model="mas.trigger_thres_cond[0].threshold" ng-change="mas.alertSettingTouch()">
-              <span class="input-group-addon">miliseconds</span>
+              <span class="input-group-addon">milliseconds</span>
             </div>
           </div>
         </div>

--- a/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/metricsAlerts.ts
+++ b/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/metricsAlerts.ts
@@ -130,14 +130,14 @@ module HawkularMetrics {
     public isSettingChange = false;
 
     public timeUnits = [
-      {value: 1, label: 'miliseconds'},
+      {value: 1, label: 'milliseconds'},
       {value: 1000, label: 'seconds'},
       {value: 60000, label: 'minutes'},
       {value: 3600000, label: 'hours'}
     ];
 
     public timeUnitsDict = {
-      '1': 'miliseconds',
+      '1': 'milliseconds',
       '1000': 'seconds',
       '60000': 'minutes',
       '3600000': 'hours'


### PR DESCRIPTION
I didn't check at all the code and if this typo needs a fix in other components.
 