### PR TITLE
[HWKINVENT-22] Update pinger to fetch the new JNDI endpoint

### DIFF
--- a/modules/pinger/src/main/java/org/hawkular/component/pinger/PingManager.java
+++ b/modules/pinger/src/main/java/org/hawkular/component/pinger/PingManager.java
@@ -29,7 +29,6 @@ import javax.ejb.LockType;
 import javax.ejb.Schedule;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -71,8 +70,8 @@ public class PingManager {
     @EJB
     TraitsPublisher traitsPublisher;
 
-    @javax.annotation.Resource(lookup = "java:global/Hawkular/ObservableInventory")
-    Inventory.Mixin.Observable inventory;
+    @javax.annotation.Resource(lookup = "java:global/Hawkular/Inventory")
+    Inventory inventory;
 
     final UrlChangesCollector urlChangesCollector = new UrlChangesCollector();
 

--- a/modules/pinger/src/main/java/org/hawkular/component/pinger/TraitsPublisher.java
+++ b/modules/pinger/src/main/java/org/hawkular/component/pinger/TraitsPublisher.java
@@ -35,8 +35,8 @@ import java.util.Map.Entry;
 @Stateless
 public class TraitsPublisher {
 
-    @javax.annotation.Resource(lookup = "java:global/Hawkular/ObservableInventory")
-    private Inventory.Mixin.Observable inventory;
+    @javax.annotation.Resource(lookup = "java:global/Hawkular/Inventory")
+    private Inventory inventory;
 
     /**
      * Stores the {@link Traits} of the given {@link PingStatus} in Hawkular Inventory.

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <version.org.hawkular.availCreator>${project.version}</version.org.hawkular.availCreator>
     <version.org.hawkular.bus>0.0.6</version.org.hawkular.bus>
     <version.org.hawkular.console>${project.version}</version.org.hawkular.console>
-    <version.org.hawkular.inventory>0.0.9</version.org.hawkular.inventory>
+    <version.org.hawkular.inventory>0.1.0</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.3.2</version.org.hawkular.metrics>
     <version.org.hawkular.nest>0.0.6</version.org.hawkular.nest>
     <version.org.hawkular.pinger>${project.version}</version.org.hawkular.pinger>


### PR DESCRIPTION
 for the "official" inventory instance instead of the abandoned mixins.

Don't merge this yet as it depends on the release of Inventory `0.1.0` and also the release of commons cassandra ear and its incorporation into dist.