### PR TITLE
HAWKULAR-379: Fixed parameter name in rest call

### DIFF
--- a/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/addUrlPage.ts
+++ b/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/addUrlPage.ts
@@ -186,7 +186,7 @@ module HawkularMetrics {
         var promises = [];
         angular.forEach(aResourceList, function(res, idx) {
           promises.push(this.HawkularMetric.GaugeMetricData(tenantId).queryMetrics({
-            resourceId: res.id, numericId: (res.id + '.status.duration'),
+            resourceId: res.id, gaugeId: (res.id + '.status.duration'),
             start: moment().subtract(1, 'hours').valueOf(), end: moment().valueOf()}, (resource) => {
             // FIXME: Work data so it works for chart ?
             res['responseTime'] = resource;

--- a/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/metricsResponsePage.ts
+++ b/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/metricsResponsePage.ts
@@ -186,7 +186,7 @@ module HawkularMetrics {
 
       if (metricId) {
         this.HawkularMetric.GaugeMetricData(this.$rootScope.currentPersona.id).queryMetrics({
-          numericId: metricId,
+          gaugeId: metricId,
           start: startTime,
           end: endTime,
           buckets: 1
@@ -219,7 +219,7 @@ module HawkularMetrics {
 
       if (metricId) {
         this.HawkularMetric.GaugeMetricData(this.$rootScope.currentPersona.id).queryMetrics({
-          numericId: metricId,
+          gaugeId: metricId,
           start: startTime,
           end: endTime,
           buckets: 120


### PR DESCRIPTION
This PR is required for the console to handle metrics correctly, but there still seem to be a server-side issue in this branch. I've got plenty of these errors in the log:
```
14:14:46,678 ERROR [org.apache.cassandra.service.CassandraDaemon] (ActiveMQ VMTransport: vm://org.hawkular.bus.broker.vrockai-laptop#7-2) Exception in thread Thread[ActiveMQ VMTransport: vm://org.hawkular.bus.broker.vrockai-laptop#7-2,5,ServerService ThreadGroup]: org.apache.activemq.broker.BrokerStoppedException: Broker BrokerService[org.hawkular.bus.broker.vrockai-laptop] is being stopped
	at org.apache.activemq.broker.TransportConnection$1.onCommand(TransportConnection.java:153)
	at org.apache.activemq.transport.ResponseCorrelator.onCommand(ResponseCorrelator.java:116)
	at org.apache.activemq.transport.MutexTransport.onCommand(MutexTransport.java:50)
	at org.apache.activemq.transport.vm.VMTransport.iterate(VMTransport.java:246)
	at org.apache.activemq.thread.PooledTaskRunner.runTask(PooledTaskRunner.java:133)
	at org.apache.activemq.thread.PooledTaskRunner$1.run(PooledTaskRunner.java:48)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```