### PR TITLE
set metrics waitForStart true by default in standalone.xml

### DIFF
--- a/dist/src/main/resources/wildfly/patches/standalone.xsl
+++ b/dist/src/main/resources/wildfly/patches/standalone.xsl
@@ -274,7 +274,12 @@
         <xsl:attribute name="name">hawkular.backend</xsl:attribute>
         <xsl:attribute name="value">&#36;{hawkular.backend:embedded_cassandra}</xsl:attribute>
       </property>
-
+      <!-- regardless of the backend, we want the metrics service to start synchronously so that
+           any dependent deployments don't deploy before startup is actually complete. -->
+      <property>
+        <xsl:attribute name="name">hawkular.metrics.waitForService</xsl:attribute>
+        <xsl:attribute name="value">&#36;{hawkular.metrics.waitForService:True}</xsl:attribute>
+      </property>
       <xsl:choose>
         <xsl:when test="$kettle.build.type='dev'">
         <property>


### PR DESCRIPTION
Although using embedded cassandra should also enable the waitForService option, when embedded C* goes away we will still want this option enable. With this option deployments can add dependencies on api-jaxrs to ensure metrics is initialized (and possibly install the schema) before themselves getting deployed.