### PR TITLE
Update dist to use Inventory 0.1.0.Alpha3.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <version.org.hawkular.bus>0.1.1</version.org.hawkular.bus>
     <version.org.hawkular.commons>0.1.1.Final</version.org.hawkular.commons>
     <version.org.hawkular.console>${project.version}</version.org.hawkular.console>
-    <version.org.hawkular.inventory>0.1.0.Alpha2</version.org.hawkular.inventory>
+    <version.org.hawkular.inventory>0.1.0.Alpha3</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.4.0.Final</version.org.hawkular.metrics>
     <version.org.hawkular.nest>0.1.1</version.org.hawkular.nest>
     <version.org.hawkular.pinger>${project.version}</version.org.hawkular.pinger>


### PR DESCRIPTION
**This is different from https://github.com/hawkular/hawkular/tree/dev/inventory-0.1.0.Alpha3**.

On top of the tested `0.1.0.Alpha2` which is currently in master, `0.1.0.Alpha3` contains only a fix for bug https://issues.jboss.org/browse/HWKINVENT-54 and therefore gets rid of the ugly error where agent is not able to fully sync its resource types with the server.

No other changes are present and most notably, no UI changes are necessary for this to work in Hawkular 1.0.0.Alpha2.

