### PR TITLE
HAWKULAR-366 : Fix availability info for URL list

### DIFF
--- a/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/addUrlPage.ts
+++ b/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/addUrlPage.ts
@@ -194,7 +194,8 @@ module HawkularMetrics {
           promises.push(this.HawkularMetric.AvailabilityMetricData(tenantId).query({
             availabilityId: res.id, distinct: true,
             start: 1, end: moment().valueOf()}, (resource) => {
-            res['isUp'] = (resource[0] && resource[0].value === 'up');
+              resource.reverse(); // FIXME: HAWKULAR-366
+              res['isUp'] = (resource[0] && resource[0].value === 'up');
           }).$promise);
           promises.push(this.HawkularMetric.AvailabilityMetricData(tenantId).query({
             availabilityId: res.id,


### PR DESCRIPTION
The fix reverses the results array, but metrics should return it in reverse order (more recent first)