### PR TITLE
HAWKULAR-347 : Fix downtime information in URL availability detail tab

### DIFF
--- a/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/metricsAvailabilityPage.ts
+++ b/ui/console/src/main/scripts/plugins/metrics/plugins/metrics/ts/metricsAvailabilityPage.ts
@@ -78,7 +78,7 @@ module HawkularMetrics {
           this.refreshAvailPageNow(this.getResourceId());
         }
       });
-      
+
       if ($rootScope.currentPersona) {
         waitForResourceId();
       } else {
@@ -149,10 +149,10 @@ module HawkularMetrics {
 
             if (availResponse && !_.last(availResponse).empty) {
 
-              this.uptimeRatio = _.last(availResponse).uptimeRatio;
-              this.downtimeDuration = Math.round(_.last(availResponse).downtimeDuration);
+              // FIXME: HAWKULAR-347 - this.uptimeRatio = _.last(availResponse).uptimeRatio;
+              // FIXME: HAWKULAR-347 - this.downtimeDuration = Math.round(_.last(availResponse).downtimeDuration);
               this.lastDowntime = new Date(_.last(availResponse).lastDowntime);
-              this.downtimeCount = _.last(availResponse).downtimeCount;
+              // FIXME: HAWKULAR-347 - this.downtimeCount = _.last(availResponse).downtimeCount;
               this.empty = _.last(availResponse).empty;
             }
 
@@ -182,6 +182,24 @@ module HawkularMetrics {
             console.dir(response);
             this.availabilityDataPoints = response;
 
+            // FIXME: HAWKULAR-347
+            var downtimeDuration = 0;
+            var lastUptime = +moment();
+            var lastDowntime = -1;
+            var downtimeCount = 0;
+            _.each(response.slice(0).reverse(), function(status, idx) {
+              if (status['value'] === 'down') {
+                lastDowntime = status['timestamp'];
+                downtimeDuration += (lastUptime - lastDowntime);
+                downtimeCount++;
+              } else {
+                lastUptime = status['timestamp'];
+              }
+            });
+
+            this.downtimeDuration = downtimeDuration;
+            this.uptimeRatio = 1 - downtimeDuration / (+moment() - response[0]['timestamp']);
+            this.downtimeCount = downtimeCount;
           }, (error) => {
             this.$log.error('Error Loading Avail data');
             toastr.error('Error Loading Avail Data: ' + error);


### PR DESCRIPTION
Currently the metrics endpoint is returning data as if we had been monitoring for the whole specified time range, which may not be the case. This should be fixed in metrics.