### PR TITLE
HAWKULAR-415 : Show secondary unit in humanized downtime information

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/availability.html
+++ b/console/src/main/scripts/plugins/metrics/html/availability.html
@@ -24,17 +24,11 @@
           <span class="hk-item">Availability</span>
         </div>
         <div class="col-sm-3 hk-summary-item">
-          <!--
-          <span class="hk-data" ng-if="vm.downtimeDuration < 60000">{{ vm.downtimeDuration / 1000 | nduration:'s\' seconds\'' }}</span>
-          <span class="hk-data" ng-if="vm.downtimeDuration >= 60000 && vm.downtimeDuration < 7200000">{{ vm.downtimeDuration | nduration:'m\' minutes and \'ss\' seconds\'' }}</span>
-          <span class="hk-data" ng-if="vm.downtimeDuration >= 7200000 && vm.downtimeDuration < 172800000">{{ vm.downtimeDuration | nduration:'h\' hours and \'m\' minutes\'' }}</span>
-          <span class="hk-data" ng-if="vm.downtimeDuration >= 172800000">{{ vm.downtimeDuration | nduration:'d\' days and \'h\' hours\'' }}</span>
-          -->
           <span class="hk-data" ng-hide="vm.downtimeDuration">Always Up</span>
-          <span class="hk-data" ng-if="vm.downtimeDuration && vm.downtimeDuration < 60000" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1500" tooltip="{{ vm.downtimeDuration | duration:'ss\'s\'' }}">{{ vm.downtimeDuration | duration:'s\' seconds\'' }}</span>
-          <span class="hk-data" ng-if="vm.downtimeDuration >= 60000 && vm.downtimeDuration < 7200000" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1500" tooltip="{{ vm.downtimeDuration | duration:'mm\'m\'ss\'s\'' }}">{{ vm.downtimeDuration | duration:'m\' minutes\'' }}</span>
-          <span class="hk-data" ng-if="vm.downtimeDuration >= 7200000 && vm.downtimeDuration < 172800000" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1500" tooltip="{{ vm.downtimeDuration | duration:'hh\'h\'mm\'m\'ss\'s\'' }}">{{ vm.downtimeDuration | duration:'h\' hours\'' }}</span>
-          <span class="hk-data" ng-if="vm.downtimeDuration >= 172800000" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1500" tooltip="{{ vm.downtimeDuration | duration:'d\'d \'hh\'h\'mm\'m\'ss\'s\'' }}">{{ vm.downtimeDuration | duration:'d\' days\'' }}</span>
+          <span class="hk-data" ng-if="vm.downtimeDuration && vm.downtimeDuration < 60000" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1500" tooltip="{{ vm.downtimeDuration | duration:'ss\'s\'' }}" ng-bind-html="vm.downtimeDuration | duration:'s\'<span> seconds</span>\''"></span>
+          <span class="hk-data" ng-if="vm.downtimeDuration >= 60000 && vm.downtimeDuration < 7200000" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1500" tooltip="{{ vm.downtimeDuration | duration:'mm\'m\'ss\'s\'' }}" ng-bind-html="vm.downtimeDuration | duration:'m\'<span> minutes</span>\' s\'<span> seconds</span>\''"></span>
+          <span class="hk-data" ng-if="vm.downtimeDuration >= 7200000 && vm.downtimeDuration < 172800000" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1500" tooltip="{{ vm.downtimeDuration | duration:'hh\'h\'mm\'m\'ss\'s\'' }}"  ng-bind-html="vm.downtimeDuration | duration:'h\'<span> hours</span>\' m\'<span> minutes</span>\''"></span>
+          <span class="hk-data" ng-if="vm.downtimeDuration >= 172800000" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1500" tooltip="{{ vm.downtimeDuration | duration:'d\'d \'hh\'h\'mm\'m\'ss\'s\'' }}" ng-bind-html="vm.downtimeDuration | duration:'d\'<span> days</span>\' h\'<span> hours</span>\''"></span>
           <span class="hk-item">Total Downtime Duration</span>
         </div>
         <div class="col-sm-3 hk-summary-item">


### PR DESCRIPTION
Because "2 hours" is not accurate when it's actually "2 hours 59 minutes"