### PR TITLE
Travis badge with status only of builds of master branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,7 +21,7 @@ the overall Hawkular instance
 
 ifdef::env-github[]
 [link=https://travis-ci.org/hawkular/hawkular]
-image:https://travis-ci.org/hawkular/hawkular.svg["Build Status", link="https://travis-ci.org/hawkular/hawkular"]
+image:https://travis-ci.org/hawkular/hawkular.svg?branch=master["Build Status", link="https://travis-ci.org/hawkular/hawkular"]
 endif::[]
 
 == Building


### PR DESCRIPTION
Travis shows red badge on the GitHub readme even if some build for other branch fails, in my opinion and in ideal world the badge should show the status of the branch I am looking at in the GitHub, unfortunatelly it's not currently possible (https://github.com/travis-ci/travis-ci/issues/1892). So at least let's make the icon mean the status of the last build for master branch, and not 'status of the last build of any branch'