### PR TITLE
enabling travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: java
 # Enable container-based infrastructure
 # see http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
+
+# manage the caches here https://travis-ci.org/hawkular/hawkular/caches
+cache:
+  directories:
+  - $HOME/.m2/repository
 jdk:
 - oraclejdk8
 install:


### PR DESCRIPTION
same thing as inventory has (http://git.io/vYT7m, https://travis-ci.org/hawkular/hawkular-inventory/caches) and newly also metrics