### PR TITLE
Revert "HAWKULAR-478 UxD change: Url list last downtime is no precise…

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/availability.html
+++ b/console/src/main/scripts/plugins/metrics/html/availability.html
@@ -34,14 +34,12 @@
           <span class="hk-data" ng-show="vm.downtimeDuration" tooltip-trigger tooltip-placement="top"
                 tooltip-popup-delay="1500"
                 tooltip="{{ vm.downtimeDuration | duration:'d\'d \'h\'h \'m\'min \'s\' s\'' }}"><ph
-            ng-repeat="val in vm.downtimeDurationJson">{{val.value}}<span> {{val.unit}}</span></ph></span>
+            ng-repeat="val in vm.downtimeDurationJson">{{val.value}}<span> {{val.unit}} </span></ph></span>
           <span class="hk-item">Total Downtime Duration</span>
         </div>
         <div class="col-sm-3 hk-summary-item">
-          <span class="hk-data"
-                ng-hide="vm.lastDowntime.valueOf() === 0 || (vm.availabilityDataPoints.length === 1 && vm.availabilityDataPoints[0].value === 'down')"> {{ vm.lastDowntime | date:'d MMM HH:mm:ss' }}</span>
-          <span class="hk-data"
-                ng-show="vm.availabilityDataPoints.length === 1 && vm.availabilityDataPoints[0].value === 'down'">Always Down</span>
+          <span class="hk-data" ng-hide="vm.lastDowntime.valueOf() === 0 || (vm.availabilityDataPoints.length === 1 && vm.availabilityDataPoints[0].value === 'down')" am-time-ago="vm.lastDowntime" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1500" tooltip="{{ vm.lastDowntime | date:'d MMM HH:mm:ss' }}"></span>
+          <span class="hk-data" ng-show="vm.availabilityDataPoints.length === 1 && vm.availabilityDataPoints[0].value === 'down'">Always Down</span>
           <span class="hk-data" ng-show="!vm.lastDowntime || vm.lastDowntime.valueOf() === 0">Always Up</span>
           <span class="hk-item">Last Downtime</span>
         </div>

--- a/console/src/main/scripts/plugins/metrics/html/url-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-list.html
@@ -66,7 +66,7 @@
           </div>
           <div class="col-sm-3 hk-summary-item">
             <a href="/hawkular-ui/url/availability/{{res.id}}">
-              <span class="hk-data" ng-show="res.lastDowntime > 0">{{res.lastDowntime| date:'d MMM HH:mm:ss' }}</span>
+              <span class="hk-data" ng-show="res.lastDowntime > 0" am-time-ago="res.lastDowntime"></span>
               <span class="hk-data" ng-show="res.lastDowntime <= 0">n/a</span>
               <span class="hk-item">Last Downtime</span>
             </a>


### PR DESCRIPTION
… enough. It has been decided to keep the format in relative time not timestamp.

This reverts commit 6a9cb7853c6fa56b1367d13a2fe80ba6ce17c581.

# Conflicts:
#	console/src/main/scripts/plugins/metrics/html/availability.html