### PR TITLE
Adding two new handy parameters for hawkular

### DIFF
--- a/dist/src/main/resources/wildfly/patches/standalone.xsl
+++ b/dist/src/main/resources/wildfly/patches/standalone.xsl
@@ -95,6 +95,11 @@
         <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.inventory:INFO}</xsl:text></xsl:attribute>
       </level>
     </logger>
+    <logger category="org.hawkular.inventory.rest.requests">
+      <level>
+        <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.inventory.rest.requests:INFO}</xsl:text></xsl:attribute>
+      </level>
+    </logger>
     <logger category="org.hawkular.metrics">
       <level>
         <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.metrics:INFO}</xsl:text></xsl:attribute>
@@ -349,7 +354,7 @@
                  numAvailSchedulerThreads="3">
         <xsl:attribute name="enabled">
           <xsl:choose>
-            <xsl:when test="$kettle.build.type='dev'">true</xsl:when>
+            <xsl:when test="$kettle.build.type='dev'">${hawkular.agent.enabled:true}</xsl:when>
             <xsl:otherwise>false</xsl:otherwise>
           </xsl:choose>
         </xsl:attribute>


### PR DESCRIPTION
Two things:
* adding a new logging category for rest requests in inventory 
`-Dhawkular.log.inventory.rest.requests=DEBUG`
* adding a way to disable the agent subsystem by Java system property 
`-Dhawkular.agent.enabled=false`

Agent should not be disabled by default, it just makes things faster if you want to skip the discovery process and test something unrelated. I think, this could be handy also for the integration tests, where we are creating some entities in the inventory and then checking their presence. If the agent is disabled during this process it should remove a lot of side-effects caused by the agent feeding the resources/types/etc. during this tests.

(both params should be passed to the `standalone.sh` not to the mvn)