### PR TITLE
HAWKULAR-553 Additional condition to skip adding invalid URL

### DIFF
--- a/console/src/main/scripts/plugins/metrics/ts/urlList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/urlList.ts
@@ -84,6 +84,11 @@ module HawkularMetrics {
     }
 
     public addUrl(url:string):void {
+
+      if (this.$scope.addUrlForm.$invalid) {
+        return;
+      }
+
       this.addProgress = true;
 
       var resourceId = this.md5.createHash(url || '');


### PR DESCRIPTION
I don't have Safari to test this and I don't know why it submits an invalid form, but this should fix the issue (although may not be the ideal way to do so).