### PR TITLE
Bump versions in the light of Alpha5

### DIFF
--- a/dist/docker-compose.yml
+++ b/dist/docker-compose.yml
@@ -29,6 +29,7 @@ hawkular:
   environment:
     - HAWKULAR_BACKEND=cassandra
     - CASSANDRA_NODES=myCassandra
+
 myCassandra:
-  image: cassandra:2.1
+  image: cassandra:2.2
 

--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -28,7 +28,7 @@ USER root
 RUN unzip -qq -d /opt /opt/hawkular.zip;\
     rm /opt/hawkular.zip;\
     mkdir /opt/data;
-#    /opt/hawkular-1.0.0.Alpha4-SNAPSHOT/bin/add-user.sh hawkularadmin hawkularadmin --silent
+#    /opt/hawkular-1.0.0.Alpha5-SNAPSHOT/bin/add-user.sh hawkularadmin hawkularadmin --silent
 
 # env variable controlling which Cassandra to use. Choose 'embeded_cassandra' or 'cassandra'
 env HAWKULAR_BACKEND=embedded_cassandra
@@ -42,4 +42,4 @@ VOLUME /opt/data
 # Internal ports visible to the outside
 EXPOSE 8080 8443
 
-CMD ["/opt/hawkular-1.0.0.Alpha4-SNAPSHOT/bin/standalone.sh","-b","0.0.0.0","-bmanagement","0.0.0.0","-Djboss.server.data.dir=/opt/data"]
+CMD ["/opt/hawkular-1.0.0.Alpha5-SNAPSHOT/bin/standalone.sh","-b","0.0.0.0","-bmanagement","0.0.0.0","-Djboss.server.data.dir=/opt/data"]

--- a/dist/docker/README.adoc
+++ b/dist/docker/README.adoc
@@ -76,12 +76,12 @@ docker run -dP  -e HAWKULAR_BACKEND=cassandra -e CASSANDRA_NODES=10.1.2.3 hawkul
 It is possible to use a linked Cassandra Docker container. For this to work you need to
 first start Cassandra and then Hawkular.
 
-.NOTE Hawkular needs Cassandra 2.1.x - so best use an image with the 2.1 tag.
+.NOTE Hawkular from Alpha5 on needs Cassandra 2.2.x - so best use an image with the _2.2_ tag.
 
 .Start the Cassandra container
 [source,shell]
 --
-docker run --name my_cassandra -d cassandra:2.1  # <1>
+docker run --name my_cassandra -d cassandra:2.2  # <1>
 --
 <1> We have provided an explicit container name of _my_cassandra_ to distinguish it from other potentially available
 Cassandra containers. If you don't provide a name _cassandra_ is taken.
@@ -106,7 +106,7 @@ you can mount an explicit host directory to be used.
 .Run Cassandra with external data directory
 [source,shell]
 --
-docker run -v /Users/hrupp/tmp/cassandra:/var/lib/cassandra/data --name my_cassandra -d  cassandra:2.1
+docker run -v /Users/hrupp/tmp/cassandra:/var/lib/cassandra/data --name my_cassandra -d  cassandra:2.2
 --
 
 === Using docker-compose
@@ -114,7 +114,8 @@ docker run -v /Users/hrupp/tmp/cassandra:/var/lib/cassandra/data --name my_cassa
 Docker has a tool http://docs.docker.com/compose/[`docker-compose`], that can be used to instrument a full application
  including linking of containers.
 
-You need to separately http://docs.docker.com/compose/install/[download compose] and can then start
+You need to separately http://docs.docker.com/compose/install/[download compose] footnote:[This is now embedded in
+the Docker Toolbox for OS/X] and can then start
 Hawkular with a linked Cassandra container:
 
 [source,shell]


### PR DESCRIPTION
Bump the versions for Docker for the Alpha5 release stream
- Hawkular to 1.0.0.Alpha5
- Cassandra to 2.2