### PR TITLE
Refactor alertsManager.ts

### DIFF
--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesAlerts.ts
@@ -28,7 +28,7 @@ module HawkularMetrics {
 
       let connTriggerId = this.resourceId + '_ds_conn';
 
-      let connDefinitionPromise = this.HawkularAlertsManager.getAlertDefinition(connTriggerId)
+      let connDefinitionPromise = this.HawkularAlertsManager.getTrigger(connTriggerId)
         .then((alertDefinitionData) => {
           this.$log.debug('alertDefinitionData', 'conn', alertDefinitionData);
           this.triggerDefinition['conn'] = alertDefinitionData;
@@ -43,7 +43,7 @@ module HawkularMetrics {
 
       let respTriggerId = this.resourceId + '_ds_resp';
 
-      let respDefinitionPromise = this.HawkularAlertsManager.getAlertDefinition(respTriggerId)
+      let respDefinitionPromise = this.HawkularAlertsManager.getTrigger(respTriggerId)
         .then((alertDefinitionData) => {
 
           this.$log.debug('alertDefinitionData', 'resp', alertDefinitionData);
@@ -93,7 +93,7 @@ module HawkularMetrics {
         connAlertDefinition.conditions[0].threshold = this.adm.conn.conditionThreshold;
       }
 
-      let connSavePromise = this.HawkularAlertsManager.saveAlertDefinition(connAlertDefinition,
+      let connSavePromise = this.HawkularAlertsManager.updateTrigger(connAlertDefinition,
         errorCallback, this.triggerDefinition.conn);
 
       // Responsiveness part
@@ -117,15 +117,25 @@ module HawkularMetrics {
       let condWaitPromise = condWaitDefer.promise;
 
       if (!this.adm.resp.waitTimeEnabled && this.admBak.resp.waitTimeEnabled) {
+        /*
+          FIXME: To update the trigger without this condition
+          NOTE: This is commented here, as in alerts 0.4.x conditions are managed as a block in one call
+
+         */
         // delete
+        /*
         condWaitPromise = this.HawkularAlertsManager.deleteCondition(respTriggerId,
           respAlertDefinition.conditions[idWait].conditionId);
-
+        */
         delete respAlertDefinition.conditions[idWait];
       } else if (this.adm.resp.waitTimeEnabled && !this.admBak.resp.waitTimeEnabled) {
+        /*
+          FIXME: To update the trigger with a new condition
+          NOTE: This si commented here, as in alerts 0.4.x conditions are managed as a block in one call
+         */
         // create
         let resId = respTriggerId.slice(0,-8);
-
+        /*
         condWaitPromise = this.HawkularAlertsManager.createCondition(respTriggerId, {
           triggerId: respTriggerId,
           type: 'THRESHOLD',
@@ -133,6 +143,7 @@ module HawkularMetrics {
           threshold: this.adm.resp.waitTimeThreshold,
           operator: 'GT'
         });
+        */
       } else {
         condWaitDefer.resolve();
       }
@@ -143,15 +154,24 @@ module HawkularMetrics {
 
       // FIXME: The condition id changes if previous was added/deleted ..
       if (!self.adm.resp.creationTimeEnabled && self.admBak.resp.creationTimeEnabled) {
+        /*
+         FIXME: To update the trigger without this condition
+         NOTE: This is commented here, as in alerts 0.4.x conditions are managed as a block in one call
+         */
         // delete
+        /*
         condCreaPromise = self.HawkularAlertsManager.deleteCondition(respTriggerId,
           respAlertDefinition.conditions[idCreation].conditionId);
-
+        */
         delete respAlertDefinition.conditions[idCreation];
       } else if (self.adm.resp.creationTimeEnabled && !self.admBak.resp.creationTimeEnabled) {
+        /*
+         FIXME: To update the trigger with a new condition
+         NOTE: This si commented here, as in alerts 0.4.x conditions are managed as a block in one call
+         */
         // create
         let resId = respTriggerId.slice(0,-8);
-
+        /*
         condCreaPromise = self.HawkularAlertsManager.createCondition(respTriggerId, {
           triggerId: respTriggerId,
           type: 'THRESHOLD',
@@ -159,6 +179,7 @@ module HawkularMetrics {
           threshold: self.adm.resp.creationTimeThreshold,
           operator: 'GT'
         });
+        */
       } else {
         condCreaDefer.resolve();
       }
@@ -170,7 +191,7 @@ module HawkularMetrics {
         respAlertDefinition.conditions[idCreation].threshold = this.adm.resp.creationTimeThreshold;
       }
 
-      let respSavePromise = this.HawkularAlertsManager.saveAlertDefinition(respAlertDefinition,
+      let respSavePromise = this.HawkularAlertsManager.updateTrigger(respAlertDefinition,
         errorCallback, this.triggerDefinition.resp);
 
       console.log('@PROMISES', connSavePromise, respSavePromise, condWaitPromise, condCreaPromise);

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesAlerts.ts
@@ -23,52 +23,52 @@ module HawkularMetrics {
 
   export class DatasourcesAlertSetupController extends AlertSetupController {
 
-    loadDefinitions():Array<ng.IPromise<any>> {
+    loadTriggers():Array<ng.IPromise<any>> {
       console.log('this.resourceId', this.resourceId);
 
       let connTriggerId = this.resourceId + '_ds_conn';
 
-      let connDefinitionPromise = this.HawkularAlertsManager.getTrigger(connTriggerId)
-        .then((alertDefinitionData) => {
-          this.$log.debug('alertDefinitionData', 'conn', alertDefinitionData);
-          this.triggerDefinition['conn'] = alertDefinitionData;
+      let connTriggerPromise = this.HawkularAlertsManager.getTrigger(connTriggerId)
+        .then((triggerData) => {
+          this.$log.debug('triggerData', 'conn', triggerData);
+          this.triggerDefinition['conn'] = triggerData;
 
           this.adm['conn'] = {};
-          this.adm.conn['email'] = alertDefinitionData.trigger.actions.email[0];
-          this.adm.conn['responseDuration'] = alertDefinitionData.dampenings[0].evalTimeSetting;
-          this.adm.conn['conditionThreshold'] = alertDefinitionData.conditions[0].threshold;
-          this.adm.conn['conditionEnabled'] = alertDefinitionData.trigger.enabled;
+          this.adm.conn['email'] = triggerData.trigger.actions.email[0];
+          this.adm.conn['responseDuration'] = triggerData.dampenings[0].evalTimeSetting;
+          this.adm.conn['conditionThreshold'] = triggerData.conditions[0].threshold;
+          this.adm.conn['conditionEnabled'] = triggerData.trigger.enabled;
         });
 
 
       let respTriggerId = this.resourceId + '_ds_resp';
 
-      let respDefinitionPromise = this.HawkularAlertsManager.getTrigger(respTriggerId)
-        .then((alertDefinitionData) => {
+      let respTriggerPromise = this.HawkularAlertsManager.getTrigger(respTriggerId)
+        .then((triggerData) => {
 
-          this.$log.debug('alertDefinitionData', 'resp', alertDefinitionData);
-          this.triggerDefinition['resp'] = alertDefinitionData;
+          this.$log.debug('triggerData', 'resp', triggerData);
+          this.triggerDefinition['resp'] = triggerData;
 
           this.adm['resp'] = {};
-          this.adm.resp['email'] = alertDefinitionData.trigger.actions.email[0];
-          this.adm.resp['responseDuration'] = alertDefinitionData.dampenings[0].evalTimeSetting;
+          this.adm.resp['email'] = triggerData.trigger.actions.email[0];
+          this.adm.resp['responseDuration'] = triggerData.dampenings[0].evalTimeSetting;
 
-          if (alertDefinitionData.conditions.length > 0) {
+          if (triggerData.conditions.length > 0) {
             let idCreation = 0,
               idWait = 1;
 
-            if (alertDefinitionData.conditions[0].dataId.indexOf('Creation') === -1) {
+            if (triggerData.conditions[0].dataId.indexOf('Creation') === -1) {
               idCreation = 1;
               idWait = 0;
             }
 
-            if (alertDefinitionData.conditions[idWait]) {
-              this.adm.resp['waitTimeThreshold'] = alertDefinitionData.conditions[idWait].threshold;
-              this.adm.resp['waitTimeEnabled'] = !!alertDefinitionData.conditions[idWait].threshold;
+            if (triggerData.conditions[idWait]) {
+              this.adm.resp['waitTimeThreshold'] = triggerData.conditions[idWait].threshold;
+              this.adm.resp['waitTimeEnabled'] = !!triggerData.conditions[idWait].threshold;
             }
-            if (alertDefinitionData.conditions[idCreation]) {
-              this.adm.resp['creationTimeThreshold'] = alertDefinitionData.conditions[idCreation].threshold;
-              this.adm.resp['creationTimeEnabled'] = !!alertDefinitionData.conditions[idCreation].threshold;
+            if (triggerData.conditions[idCreation]) {
+              this.adm.resp['creationTimeThreshold'] = triggerData.conditions[idCreation].threshold;
+              this.adm.resp['creationTimeEnabled'] = !!triggerData.conditions[idCreation].threshold;
             }
           }
 
@@ -79,37 +79,37 @@ module HawkularMetrics {
         });
 
 
-      return [connDefinitionPromise, respDefinitionPromise];
+      return [connTriggerPromise, respTriggerPromise];
     }
 
-    saveDefinitions(errorCallback):Array<ng.IPromise<any>> {
+    saveTriggers(errorCallback):Array<ng.IPromise<any>> {
       // Connections part
-      let connAlertDefinition = angular.copy(this.triggerDefinition.conn);
-      connAlertDefinition.trigger.enabled = this.adm.conn.conditionEnabled;
+      let connTrigger = angular.copy(this.triggerDefinition.conn);
+      connTrigger.trigger.enabled = this.adm.conn.conditionEnabled;
 
       if (this.adm.conn.conditionEnabled) {
-        connAlertDefinition.trigger.actions.email[0] = this.adm.conn.email;
-        connAlertDefinition.dampenings[0].evalTimeSetting = this.adm.conn.responseDuration;
-        connAlertDefinition.conditions[0].threshold = this.adm.conn.conditionThreshold;
+        connTrigger.trigger.actions.email[0] = this.adm.conn.email;
+        connTrigger.dampenings[0].evalTimeSetting = this.adm.conn.responseDuration;
+        connTrigger.conditions[0].threshold = this.adm.conn.conditionThreshold;
       }
 
-      let connSavePromise = this.HawkularAlertsManager.updateTrigger(connAlertDefinition,
+      let connSavePromise = this.HawkularAlertsManager.updateTrigger(connTrigger,
         errorCallback, this.triggerDefinition.conn);
 
       // Responsiveness part
-      let respAlertDefinition = angular.copy(this.triggerDefinition.resp);
+      let respTrigger = angular.copy(this.triggerDefinition.resp);
 
       let idCreation = 0,
         idWait = 1;
-      if (respAlertDefinition.conditions[0] && respAlertDefinition.conditions[0].dataId.indexOf('Creation') === -1) {
+      if (respTrigger.conditions[0] && respTrigger.conditions[0].dataId.indexOf('Creation') === -1) {
         idCreation = 1;
         idWait = 0;
       }
 
-      respAlertDefinition.trigger.actions.email[0] = this.adm.resp.email;
-      respAlertDefinition.dampenings[0].evalTimeSetting = this.adm.resp.responseDuration;
+      respTrigger.trigger.actions.email[0] = this.adm.resp.email;
+      respTrigger.dampenings[0].evalTimeSetting = this.adm.resp.responseDuration;
 
-      let respTriggerId = respAlertDefinition.trigger.id;
+      let respTriggerId = respTrigger.trigger.id;
 
       // Handle changes in conditions
 
@@ -127,7 +127,7 @@ module HawkularMetrics {
         condWaitPromise = this.HawkularAlertsManager.deleteCondition(respTriggerId,
           respAlertDefinition.conditions[idWait].conditionId);
         */
-        delete respAlertDefinition.conditions[idWait];
+        delete respTrigger.conditions[idWait];
       } else if (this.adm.resp.waitTimeEnabled && !this.admBak.resp.waitTimeEnabled) {
         /*
           FIXME: To update the trigger with a new condition
@@ -163,7 +163,7 @@ module HawkularMetrics {
         condCreaPromise = self.HawkularAlertsManager.deleteCondition(respTriggerId,
           respAlertDefinition.conditions[idCreation].conditionId);
         */
-        delete respAlertDefinition.conditions[idCreation];
+        delete respTrigger.conditions[idCreation];
       } else if (self.adm.resp.creationTimeEnabled && !self.admBak.resp.creationTimeEnabled) {
         /*
          FIXME: To update the trigger with a new condition
@@ -184,14 +184,14 @@ module HawkularMetrics {
         condCreaDefer.resolve();
       }
 
-      if (respAlertDefinition.conditions[idWait]) {
-        respAlertDefinition.conditions[idWait].threshold = this.adm.resp.waitTimeThreshold;
+      if (respTrigger.conditions[idWait]) {
+        respTrigger.conditions[idWait].threshold = this.adm.resp.waitTimeThreshold;
       }
-      if (respAlertDefinition.conditions[idCreation]) {
-        respAlertDefinition.conditions[idCreation].threshold = this.adm.resp.creationTimeThreshold;
+      if (respTrigger.conditions[idCreation]) {
+        respTrigger.conditions[idCreation].threshold = this.adm.resp.creationTimeThreshold;
       }
 
-      let respSavePromise = this.HawkularAlertsManager.updateTrigger(respAlertDefinition,
+      let respSavePromise = this.HawkularAlertsManager.updateTrigger(respTrigger,
         errorCallback, this.triggerDefinition.resp);
 
       console.log('@PROMISES', connSavePromise, respSavePromise, condWaitPromise, condCreaPromise);

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmAlerts.ts
@@ -268,7 +268,7 @@ module HawkularMetrics {
     // TODO - Get the actual data from backend
     public maxUsage: number = AppServerJvmDetailsController.MAX_HEAP;
 
-    loadDefinitions():Array<ng.IPromise<any>> {
+    loadTriggers():Array<ng.IPromise<any>> {
       function floor2Dec(doubleValue) {
         return Math.floor(doubleValue * 100)/100;
       }
@@ -277,94 +277,94 @@ module HawkularMetrics {
 
       var heapTriggerId: string = this.$routeParams.resourceId + '_jvm_pheap';
 
-      var heapDefinitionPromise = this.HawkularAlertsManager.getTrigger(heapTriggerId).then(
-        (alertDefinitionData) => {
-          this.triggerDefinition['heap'] = alertDefinitionData;
+      var heapTriggerPromise = this.HawkularAlertsManager.getTrigger(heapTriggerId).then(
+        (triggerData) => {
+          this.triggerDefinition['heap'] = triggerData;
 
           this.adm.heap = {};
-          this.adm.heap['email'] = alertDefinitionData.trigger.actions.email[0];
-          this.adm.heap['responseDuration'] = alertDefinitionData.dampenings[0].evalTimeSetting;
-          this.adm.heap['conditionGtEnabled'] = alertDefinitionData.conditions[0].thresholdHigh < this.maxUsage;
-          this.adm.heap['conditionGtPercent'] = alertDefinitionData.conditions[0].thresholdHigh > 0 ?
-            floor2Dec(alertDefinitionData.conditions[0].thresholdHigh * 100 / this.maxUsage) : 0;
-          this.adm.heap['conditionLtEnabled'] = alertDefinitionData.conditions[0].thresholdLow > 0;
-          this.adm.heap['conditionLtPercent'] = alertDefinitionData.conditions[0].thresholdLow > 0 ?
-            floor2Dec(alertDefinitionData.conditions[0].thresholdLow * 100 / this.maxUsage ): 0;
+          this.adm.heap['email'] = triggerData.trigger.actions.email[0];
+          this.adm.heap['responseDuration'] = triggerData.dampenings[0].evalTimeSetting;
+          this.adm.heap['conditionGtEnabled'] = triggerData.conditions[0].thresholdHigh < this.maxUsage;
+          this.adm.heap['conditionGtPercent'] = triggerData.conditions[0].thresholdHigh > 0 ?
+            floor2Dec(triggerData.conditions[0].thresholdHigh * 100 / this.maxUsage) : 0;
+          this.adm.heap['conditionLtEnabled'] = triggerData.conditions[0].thresholdLow > 0;
+          this.adm.heap['conditionLtPercent'] = triggerData.conditions[0].thresholdLow > 0 ?
+            floor2Dec(triggerData.conditions[0].thresholdLow * 100 / this.maxUsage ): 0;
         });
 
       // Non-Heap Usage trigger definition
       var nheapTriggerId: string = this.$routeParams.resourceId + '_jvm_nheap';
 
-      var nheapDefinitionPromise = this.HawkularAlertsManager.getTrigger(nheapTriggerId).then(
-        (alertDefinitionData) => {
-          this.triggerDefinition['nheap'] = alertDefinitionData;
+      var nheapTriggerPromise = this.HawkularAlertsManager.getTrigger(nheapTriggerId).then(
+        (triggerData) => {
+          this.triggerDefinition['nheap'] = triggerData;
 
           this.adm.nheap = {};
-          this.adm.nheap['email'] = alertDefinitionData.trigger.actions.email[0];
-          this.adm.nheap['responseDuration'] = alertDefinitionData.dampenings[0].evalTimeSetting;
-          this.adm.nheap['conditionGtEnabled'] = alertDefinitionData.conditions[0].thresholdHigh < this.maxUsage;
-          this.adm.nheap['conditionGtPercent'] = alertDefinitionData.conditions[0].thresholdHigh > 0 ?
-            floor2Dec(alertDefinitionData.conditions[0].thresholdHigh * 100 / this.maxUsage) : 0;
-          this.adm.nheap['conditionLtEnabled'] = alertDefinitionData.conditions[0].thresholdLow > 0;
-          this.adm.nheap['conditionLtPercent'] = alertDefinitionData.conditions[0].thresholdLow > 0 ?
-            floor2Dec(alertDefinitionData.conditions[0].thresholdLow * 100 / this.maxUsage) : 0;
+          this.adm.nheap['email'] = triggerData.trigger.actions.email[0];
+          this.adm.nheap['responseDuration'] = triggerData.dampenings[0].evalTimeSetting;
+          this.adm.nheap['conditionGtEnabled'] = triggerData.conditions[0].thresholdHigh < this.maxUsage;
+          this.adm.nheap['conditionGtPercent'] = triggerData.conditions[0].thresholdHigh > 0 ?
+            floor2Dec(triggerData.conditions[0].thresholdHigh * 100 / this.maxUsage) : 0;
+          this.adm.nheap['conditionLtEnabled'] = triggerData.conditions[0].thresholdLow > 0;
+          this.adm.nheap['conditionLtPercent'] = triggerData.conditions[0].thresholdLow > 0 ?
+            floor2Dec(triggerData.conditions[0].thresholdLow * 100 / this.maxUsage) : 0;
         });
 
       // Garbage Collection trigger definition
       var garbaTriggerId: string = this.$routeParams.resourceId + '_jvm_garba';
 
-      var garbaDefinitionPromise = this.HawkularAlertsManager.getTrigger(garbaTriggerId).then(
-        (alertDefinitionData) => {
-          this.triggerDefinition['garba'] = alertDefinitionData;
+      var garbaTriggerPromise = this.HawkularAlertsManager.getTrigger(garbaTriggerId).then(
+        (triggerData) => {
+          this.triggerDefinition['garba'] = triggerData;
 
           this.adm.garba = {};
-          this.adm.garba['email'] = alertDefinitionData.trigger.actions.email[0];
-          this.adm.garba['responseDuration'] = alertDefinitionData.dampenings[0].evalTimeSetting;
-          this.adm.garba['conditionEnabled'] = alertDefinitionData.trigger.enabled;
-          this.adm.garba['conditionThreshold'] = alertDefinitionData.conditions[0].threshold;
+          this.adm.garba['email'] = triggerData.trigger.actions.email[0];
+          this.adm.garba['responseDuration'] = triggerData.dampenings[0].evalTimeSetting;
+          this.adm.garba['conditionEnabled'] = triggerData.trigger.enabled;
+          this.adm.garba['conditionThreshold'] = triggerData.conditions[0].threshold;
         });
 
-      return [heapDefinitionPromise, nheapDefinitionPromise, garbaDefinitionPromise];
+      return [heapTriggerPromise, nheapTriggerPromise, garbaTriggerPromise];
     }
 
-    saveDefinitions(errorCallback):Array<ng.IPromise<any>> {
+    saveTriggers(errorCallback):Array<ng.IPromise<any>> {
 
       // Heap
-      var heapAlertDefinition = angular.copy(this.triggerDefinition.heap);
-      heapAlertDefinition.trigger.actions.email[0] = this.adm.heap.email;
-      heapAlertDefinition.dampenings[0].evalTimeSetting = this.adm.heap.responseDuration;
-      heapAlertDefinition.conditions[0].thresholdHigh = this.adm.heap.conditionGtEnabled ?
+      var heapTrigger = angular.copy(this.triggerDefinition.heap);
+      heapTrigger.trigger.actions.email[0] = this.adm.heap.email;
+      heapTrigger.dampenings[0].evalTimeSetting = this.adm.heap.responseDuration;
+      heapTrigger.conditions[0].thresholdHigh = this.adm.heap.conditionGtEnabled ?
       this.maxUsage * this.adm.heap.conditionGtPercent / 100 : this.maxUsage;
-      heapAlertDefinition.conditions[0].thresholdLow = this.adm.heap.conditionLtEnabled ?
+      heapTrigger.conditions[0].thresholdLow = this.adm.heap.conditionLtEnabled ?
       this.maxUsage * this.adm.heap.conditionLtPercent / 100 : 0;
 
-      var heapSavePromise = this.HawkularAlertsManager.updateTrigger(heapAlertDefinition, errorCallback,
+      var heapSavePromise = this.HawkularAlertsManager.updateTrigger(heapTrigger, errorCallback,
         this.triggerDefinition.heap);
 
       // Non Heap
-      var nheapAlertDefinition = angular.copy(this.triggerDefinition.nheap);
-      nheapAlertDefinition.trigger.actions.email[0] = this.adm.nheap.email;
-      nheapAlertDefinition.dampenings[0].evalTimeSetting = this.adm.nheap.responseDuration;
-      nheapAlertDefinition.conditions[0].thresholdHigh = this.adm.nheap.conditionGtEnabled ?
+      var nheapTrigger = angular.copy(this.triggerDefinition.nheap);
+      nheapTrigger.trigger.actions.email[0] = this.adm.nheap.email;
+      nheapTrigger.dampenings[0].evalTimeSetting = this.adm.nheap.responseDuration;
+      nheapTrigger.conditions[0].thresholdHigh = this.adm.nheap.conditionGtEnabled ?
       this.maxUsage * this.adm.nheap.conditionGtPercent / 100 : this.maxUsage;
-      nheapAlertDefinition.conditions[0].thresholdLow = this.adm.nheap.conditionLtEnabled ?
+      nheapTrigger.conditions[0].thresholdLow = this.adm.nheap.conditionLtEnabled ?
       this.maxUsage * this.adm.nheap.conditionLtPercent / 100 : 0;
 
-      var nheapSavePromise = this.HawkularAlertsManager.updateTrigger(nheapAlertDefinition, errorCallback,
+      var nheapSavePromise = this.HawkularAlertsManager.updateTrigger(nheapTrigger, errorCallback,
         this.triggerDefinition.nheap);
 
       // Garbage Collection
-      var garbaAlertDefinition = angular.copy(this.triggerDefinition.garba);
-      garbaAlertDefinition.trigger.enabled = this.adm.garba.conditionEnabled;
+      var garbaTrigger = angular.copy(this.triggerDefinition.garba);
+      garbaTrigger.trigger.enabled = this.adm.garba.conditionEnabled;
 
       if (this.adm.garba.conditionEnabled) {
-        garbaAlertDefinition.trigger.actions.email[0] = this.adm.garba.email;
-        garbaAlertDefinition.dampenings[0].evalTimeSetting = this.adm.garba.responseDuration;
-        garbaAlertDefinition.conditions[0].threshold = this.adm.garba.conditionEnabled ?
+        garbaTrigger.trigger.actions.email[0] = this.adm.garba.email;
+        garbaTrigger.dampenings[0].evalTimeSetting = this.adm.garba.responseDuration;
+        garbaTrigger.conditions[0].threshold = this.adm.garba.conditionEnabled ?
           this.adm.garba.conditionThreshold : 0;
       }
 
-      var garbaSavePromise = this.HawkularAlertsManager.updateTrigger(garbaAlertDefinition, errorCallback,
+      var garbaSavePromise = this.HawkularAlertsManager.updateTrigger(garbaTrigger, errorCallback,
         this.triggerDefinition.garba);
 
       return [heapSavePromise, nheapSavePromise, garbaSavePromise];

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmAlerts.ts
@@ -67,7 +67,7 @@ module HawkularMetrics {
     public openSetup():void {
       // Check if trigger exists on alerts setup modal open. If not, create the trigger before opening the modal
 
-      var heapTriggerPromise = this.HawkularAlertsManager.getTrigger(this.resourceId + '_jvm_pheap').then(() => {
+      var heapTriggerPromise = this.HawkularAlertsManager.existTrigger(this.resourceId + '_jvm_pheap').then(() => {
         // Jvm trigger exists, nothing to do
           this.$log.debug('Jvm trigger exists, nothing to do');
       }, () => {
@@ -79,22 +79,40 @@ module HawkularMetrics {
         var resourceId: string = triggerId.slice(0,-10);
         var dataId: string = 'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Heap Used';
 
-        return this.HawkularAlertsManager.createAlertDefinition({
-          name: triggerId,
-          id: triggerId,
-          actions: {email: [this.defaultEmail]}
-        }, {
-          type: 'RANGE',
-          dataId: dataId,
-          operatorLow: 'INCLUSIVE',
-          operatorHigh: 'INCLUSIVE',
-          thresholdLow: low || 20.0,
-          thresholdHigh: high || 80.0,
-          inRange: false
+        var fullTrigger = {
+          trigger: {
+            name: triggerId,
+            id: triggerId,
+            actions: {email: [this.defaultEmail]}
+          },
+          dampenings: [
+            {
+              triggerId: triggerId,
+              evalTimeSetting: 7 * 60000,
+              triggerMode: 'FIRING',
+              type: 'STRICT_TIME'
+            }
+          ],
+          conditions: [
+            {
+              triggerId: triggerId,
+              type: 'RANGE',
+              dataId: dataId,
+              operatorLow: 'INCLUSIVE',
+              operatorHigh: 'INCLUSIVE',
+              thresholdLow: low || 20.0,
+              thresholdHigh: high || 80.0,
+              inRange: false
+            }
+          ]
+        };
+
+        return this.HawkularAlertsManager.createTrigger(fullTrigger, () => {
+          this.$log.error('Error on Trigger creation for ' + triggerId);
         });
       });
 
-      var nonHeapTriggerPromise = this.HawkularAlertsManager.getTrigger(this.resourceId + '_jvm_nheap').then(() => {
+      var nonHeapTriggerPromise = this.HawkularAlertsManager.existTrigger(this.resourceId + '_jvm_nheap').then(() => {
         // Jvm trigger exists, nothing to do
         this.$log.debug('Jvm trigger exists, nothing to do');
       }, () => {
@@ -105,23 +123,40 @@ module HawkularMetrics {
         var triggerId: string = this.resourceId + '_jvm_nheap';
         var resourceId: string = triggerId.slice(0,-10);
         var dataId: string = 'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Heap Used';
+        var fullTrigger = {
+          trigger: {
+            name: triggerId,
+            id: triggerId,
+            actions: {email: [this.defaultEmail]}
+          },
+          dampenings: [
+            {
+              triggerId: triggerId,
+              evalTimeSetting: 7 * 60000,
+              triggerMode: 'FIRING',
+              type: 'STRICT_TIME'
+            }
+          ],
+          conditions: [
+            {
+              triggerId: triggerId,
+              type: 'RANGE',
+              dataId: dataId,
+              operatorLow: 'INCLUSIVE',
+              operatorHigh: 'INCLUSIVE',
+              thresholdLow: low || 20.0,
+              thresholdHigh: high || 80.0,
+              inRange: false
+            }
+          ]
+        };
 
-        return this.HawkularAlertsManager.createAlertDefinition({
-          name: triggerId,
-          id: triggerId,
-          actions: {email: [this.defaultEmail]}
-        }, {
-          type: 'RANGE',
-          dataId: dataId,
-          operatorLow: 'INCLUSIVE',
-          operatorHigh: 'INCLUSIVE',
-          thresholdLow: low || 20.0,
-          thresholdHigh: high || 80.0,
-          inRange: false
+        return this.HawkularAlertsManager.createTrigger(fullTrigger, () => {
+          this.$log.error('Error on Trigger creation for ' + triggerId);
         });
       });
 
-      var garbageTriggerPromise = this.HawkularAlertsManager.getTrigger(this.resourceId + '_jvm_garba').then(() => {
+      var garbageTriggerPromise = this.HawkularAlertsManager.existTrigger(this.resourceId + '_jvm_garba').then(() => {
         // Jvm trigger exists, nothing to do
         this.$log.debug('Jvm trigger exists, nothing to do');
       }, () => {
@@ -129,16 +164,33 @@ module HawkularMetrics {
         var triggerId: string = this.resourceId + '_jvm_garba';
         var resourceId: string = triggerId.slice(0,-10);
         var dataId: string = 'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Accumulated GC Duration';
+        var fullTrigger = {
+          trigger: {
+            name: triggerId,
+            id: triggerId,
+            actions: {email: [this.defaultEmail]}
+          },
+          dampenings: [
+            {
+              triggerId: triggerId,
+              evalTimeSetting: 7 * 60000,
+              triggerMode: 'FIRING',
+              type: 'STRICT_TIME'
+            }
+          ],
+          conditions: [
+            {
+              triggerId: triggerId,
+              type: 'THRESHOLD',
+              dataId: dataId,
+              threshold: 200,
+              operator: 'GT'
+            }
+          ]
+        };
 
-        return this.HawkularAlertsManager.createAlertDefinition({
-          name: triggerId,
-          id: triggerId,
-          actions: {email: [this.defaultEmail]}
-        },  {
-          type: 'THRESHOLD',
-          threshold: 200,
-          dataId: dataId,
-          operator: 'GT'
+        return this.HawkularAlertsManager.createTrigger(fullTrigger, () => {
+          this.$log.error('Error on Trigger creation for ' + triggerId);
         });
       });
 
@@ -225,7 +277,7 @@ module HawkularMetrics {
 
       var heapTriggerId: string = this.$routeParams.resourceId + '_jvm_pheap';
 
-      var heapDefinitionPromise = this.HawkularAlertsManager.getAlertDefinition(heapTriggerId).then(
+      var heapDefinitionPromise = this.HawkularAlertsManager.getTrigger(heapTriggerId).then(
         (alertDefinitionData) => {
           this.triggerDefinition['heap'] = alertDefinitionData;
 
@@ -243,7 +295,7 @@ module HawkularMetrics {
       // Non-Heap Usage trigger definition
       var nheapTriggerId: string = this.$routeParams.resourceId + '_jvm_nheap';
 
-      var nheapDefinitionPromise = this.HawkularAlertsManager.getAlertDefinition(nheapTriggerId).then(
+      var nheapDefinitionPromise = this.HawkularAlertsManager.getTrigger(nheapTriggerId).then(
         (alertDefinitionData) => {
           this.triggerDefinition['nheap'] = alertDefinitionData;
 
@@ -261,7 +313,7 @@ module HawkularMetrics {
       // Garbage Collection trigger definition
       var garbaTriggerId: string = this.$routeParams.resourceId + '_jvm_garba';
 
-      var garbaDefinitionPromise = this.HawkularAlertsManager.getAlertDefinition(garbaTriggerId).then(
+      var garbaDefinitionPromise = this.HawkularAlertsManager.getTrigger(garbaTriggerId).then(
         (alertDefinitionData) => {
           this.triggerDefinition['garba'] = alertDefinitionData;
 
@@ -286,7 +338,7 @@ module HawkularMetrics {
       heapAlertDefinition.conditions[0].thresholdLow = this.adm.heap.conditionLtEnabled ?
       this.maxUsage * this.adm.heap.conditionLtPercent / 100 : 0;
 
-      var heapSavePromise = this.HawkularAlertsManager.saveAlertDefinition(heapAlertDefinition, errorCallback,
+      var heapSavePromise = this.HawkularAlertsManager.updateTrigger(heapAlertDefinition, errorCallback,
         this.triggerDefinition.heap);
 
       // Non Heap
@@ -298,7 +350,7 @@ module HawkularMetrics {
       nheapAlertDefinition.conditions[0].thresholdLow = this.adm.nheap.conditionLtEnabled ?
       this.maxUsage * this.adm.nheap.conditionLtPercent / 100 : 0;
 
-      var nheapSavePromise = this.HawkularAlertsManager.saveAlertDefinition(nheapAlertDefinition, errorCallback,
+      var nheapSavePromise = this.HawkularAlertsManager.updateTrigger(nheapAlertDefinition, errorCallback,
         this.triggerDefinition.nheap);
 
       // Garbage Collection
@@ -312,7 +364,7 @@ module HawkularMetrics {
           this.adm.garba.conditionThreshold : 0;
       }
 
-      var garbaSavePromise = this.HawkularAlertsManager.saveAlertDefinition(garbaAlertDefinition, errorCallback,
+      var garbaSavePromise = this.HawkularAlertsManager.updateTrigger(garbaAlertDefinition, errorCallback,
         this.triggerDefinition.garba);
 
       return [heapSavePromise, nheapSavePromise, garbaSavePromise];

--- a/console/src/main/scripts/plugins/metrics/ts/metricsAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsAlerts.ts
@@ -46,9 +46,9 @@ module HawkularMetrics {
       // TODO - update the pfly notification service to support more and category based notifications containers.
       this.$rootScope.hkNotifications = {alerts: []};
 
-      let definitionPromises = this.loadDefinitions();
+      let triggersPromises = this.loadTriggers();
 
-      this.$q.all(definitionPromises).then(() => {
+      this.$q.all(triggersPromises).then(() => {
         this.admBak = angular.copy(this.adm);
         this.isSettingChange = false;
       });
@@ -78,9 +78,9 @@ module HawkularMetrics {
       let isError = false;
       // Check if email action exists
 
-      let saveDefinitionPromises = this.saveDefinitions(errorCallback);
+      let saveTriggersPromises = this.saveTriggers(errorCallback);
 
-      this.$q.all(saveDefinitionPromises).finally(()=> {
+      this.$q.all(saveTriggersPromises).finally(()=> {
         this.saveProgress = false;
 
         if (!isError) {
@@ -99,11 +99,11 @@ module HawkularMetrics {
       this.$modalInstance.dismiss('cancel');
     }
 
-    loadDefinitions():Array<ng.IPromise<any>> {
+    loadTriggers():Array<ng.IPromise<any>> {
       throw new Error('This method is abstract');
     }
 
-    saveDefinitions(errorCallback):Array<ng.IPromise<any>> {
+    saveTriggers(errorCallback):Array<ng.IPromise<any>> {
       throw new Error('This method is abstract');
     }
   }
@@ -226,32 +226,32 @@ module HawkularMetrics {
 
   export class AlertUrlAvailabilitySetupController extends AlertSetupController {
 
-    loadDefinitions():Array<ng.IPromise<any>> {
+    loadTriggers():Array<ng.IPromise<any>> {
       let availabilityTriggerId = this.$routeParams.resourceId + '_trigger_avail';
 
-      let availabilityDefinitionPromise = this.HawkularAlertsManager.getTrigger(availabilityTriggerId)
-        .then((alertDefinitionData) => {
-          this.$log.debug('alertDefinitionData', alertDefinitionData);
-          this.triggerDefinition['avail'] = alertDefinitionData;
+      let availabilityTriggerPromise = this.HawkularAlertsManager.getTrigger(availabilityTriggerId)
+        .then((triggerData) => {
+          this.$log.debug('triggerData', triggerData);
+          this.triggerDefinition['avail'] = triggerData;
 
           this.adm['avail'] = {};
-          this.adm.avail['email'] = alertDefinitionData.trigger.actions.email[0];
-          this.adm.avail['responseDuration'] = alertDefinitionData.dampenings[0].evalTimeSetting;
-          this.adm.avail['conditionEnabled'] = alertDefinitionData.trigger.enabled;
+          this.adm.avail['email'] = triggerData.trigger.actions.email[0];
+          this.adm.avail['responseDuration'] = triggerData.dampenings[0].evalTimeSetting;
+          this.adm.avail['conditionEnabled'] = triggerData.trigger.enabled;
         });
 
-      return [availabilityDefinitionPromise];
+      return [availabilityTriggerPromise];
     }
 
-    saveDefinitions(errorCallback):Array<ng.IPromise<any>> {
+    saveTriggers(errorCallback):Array<ng.IPromise<any>> {
       // Set the actual object to save
-      let availabilityAlertDefinition = angular.copy(this.triggerDefinition.avail);
-      availabilityAlertDefinition.trigger.actions.email[0] = this.adm.avail.email;
-      availabilityAlertDefinition.trigger.enabled = this.adm.avail.conditionEnabled;
-      availabilityAlertDefinition.dampenings[0].evalTimeSetting = this.adm.avail.responseDuration;
-      availabilityAlertDefinition.dampenings[1].evalTimeSetting = this.adm.avail.responseDuration;
+      let availabilityTrigger = angular.copy(this.triggerDefinition.avail);
+      availabilityTrigger.trigger.actions.email[0] = this.adm.avail.email;
+      availabilityTrigger.trigger.enabled = this.adm.avail.conditionEnabled;
+      availabilityTrigger.dampenings[0].evalTimeSetting = this.adm.avail.responseDuration;
+      availabilityTrigger.dampenings[1].evalTimeSetting = this.adm.avail.responseDuration;
 
-      let availabilitySavePromise = this.HawkularAlertsManager.updateTrigger(availabilityAlertDefinition,
+      let availabilitySavePromise = this.HawkularAlertsManager.updateTrigger(availabilityTrigger,
         errorCallback, this.triggerDefinition.avail);
 
       return [availabilitySavePromise];
@@ -264,35 +264,35 @@ module HawkularMetrics {
     loadDefinitions():Array<ng.IPromise<any>> {
       let responseTriggerId = this.$routeParams.resourceId + '_trigger_thres';
 
-      let responseDefinitionPromise = this.HawkularAlertsManager.getTrigger(responseTriggerId).then(
-        (alertDefinitionData) => {
-          this.$log.debug('alertDefinitionData', alertDefinitionData);
-          this.triggerDefinition['thres'] = alertDefinitionData;
+      let responseTriggerPromise = this.HawkularAlertsManager.getTrigger(responseTriggerId).then(
+        (triggerData) => {
+          this.$log.debug('triggerData', triggerData);
+          this.triggerDefinition['thres'] = triggerData;
 
           this.adm['thres'] = {};
-          this.adm.thres['email'] = alertDefinitionData.trigger.actions.email[0];
-          this.adm.thres['responseDuration'] = alertDefinitionData.dampenings[0].evalTimeSetting;
-          this.adm.thres['conditionEnabled'] = alertDefinitionData.trigger.enabled;
-          this.adm.thres['conditionThreshold'] = alertDefinitionData.conditions[0].threshold;
+          this.adm.thres['email'] = triggerData.trigger.actions.email[0];
+          this.adm.thres['responseDuration'] = triggerData.dampenings[0].evalTimeSetting;
+          this.adm.thres['conditionEnabled'] = triggerData.trigger.enabled;
+          this.adm.thres['conditionThreshold'] = triggerData.conditions[0].threshold;
         });
 
-      return [responseDefinitionPromise];
+      return [responseTriggerPromise];
     }
 
-    saveDefinitions(errorCallback):Array<ng.IPromise<any>> {
+    saveTriggers(errorCallback):Array<ng.IPromise<any>> {
       // Set the actual object to save
-      let responseAlertDefinition = angular.copy(this.triggerDefinition.thres);
-      responseAlertDefinition.trigger.enabled = this.adm.thres.conditionEnabled;
+      let responseTrigger = angular.copy(this.triggerDefinition.thres);
+      responseTrigger.trigger.enabled = this.adm.thres.conditionEnabled;
 
       if (this.adm.thres.conditionEnabled) {
-        responseAlertDefinition.trigger.actions.email[0] = this.adm.thres.email;
-        responseAlertDefinition.dampenings[0].evalTimeSetting = this.adm.thres.responseDuration;
-        responseAlertDefinition.dampenings[1].evalTimeSetting = this.adm.thres.responseDuration;
-        responseAlertDefinition.conditions[0].threshold = this.adm.thres.conditionThreshold;
-        responseAlertDefinition.conditions[1].threshold = this.adm.thres.conditionThreshold;
+        responseTrigger.trigger.actions.email[0] = this.adm.thres.email;
+        responseTrigger.dampenings[0].evalTimeSetting = this.adm.thres.responseDuration;
+        responseTrigger.dampenings[1].evalTimeSetting = this.adm.thres.responseDuration;
+        responseTrigger.conditions[0].threshold = this.adm.thres.conditionThreshold;
+        responseTrigger.conditions[1].threshold = this.adm.thres.conditionThreshold;
       }
 
-      let responseSavePromise = this.HawkularAlertsManager.updateTrigger(responseAlertDefinition,
+      let responseSavePromise = this.HawkularAlertsManager.updateTrigger(responseTrigger,
         errorCallback, this.triggerDefinition.thres);
 
       return [responseSavePromise];

--- a/console/src/main/scripts/plugins/metrics/ts/metricsAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsAlerts.ts
@@ -229,7 +229,7 @@ module HawkularMetrics {
     loadDefinitions():Array<ng.IPromise<any>> {
       let availabilityTriggerId = this.$routeParams.resourceId + '_trigger_avail';
 
-      let availabilityDefinitionPromise = this.HawkularAlertsManager.getAlertDefinition(availabilityTriggerId)
+      let availabilityDefinitionPromise = this.HawkularAlertsManager.getTrigger(availabilityTriggerId)
         .then((alertDefinitionData) => {
           this.$log.debug('alertDefinitionData', alertDefinitionData);
           this.triggerDefinition['avail'] = alertDefinitionData;
@@ -251,7 +251,7 @@ module HawkularMetrics {
       availabilityAlertDefinition.dampenings[0].evalTimeSetting = this.adm.avail.responseDuration;
       availabilityAlertDefinition.dampenings[1].evalTimeSetting = this.adm.avail.responseDuration;
 
-      let availabilitySavePromise = this.HawkularAlertsManager.saveAlertDefinition(availabilityAlertDefinition,
+      let availabilitySavePromise = this.HawkularAlertsManager.updateTrigger(availabilityAlertDefinition,
         errorCallback, this.triggerDefinition.avail);
 
       return [availabilitySavePromise];
@@ -264,7 +264,7 @@ module HawkularMetrics {
     loadDefinitions():Array<ng.IPromise<any>> {
       let responseTriggerId = this.$routeParams.resourceId + '_trigger_thres';
 
-      let responseDefinitionPromise = this.HawkularAlertsManager.getAlertDefinition(responseTriggerId).then(
+      let responseDefinitionPromise = this.HawkularAlertsManager.getTrigger(responseTriggerId).then(
         (alertDefinitionData) => {
           this.$log.debug('alertDefinitionData', alertDefinitionData);
           this.triggerDefinition['thres'] = alertDefinitionData;
@@ -292,7 +292,7 @@ module HawkularMetrics {
         responseAlertDefinition.conditions[1].threshold = this.adm.thres.conditionThreshold;
       }
 
-      let responseSavePromise = this.HawkularAlertsManager.saveAlertDefinition(responseAlertDefinition,
+      let responseSavePromise = this.HawkularAlertsManager.updateTrigger(responseAlertDefinition,
         errorCallback, this.triggerDefinition.thres);
 
       return [responseSavePromise];

--- a/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
@@ -125,8 +125,8 @@ module HawkularMetrics {
     }
 
     public getTrigger(triggerId: TriggerId): any {
-      var deffered = this.$q.defer();
-      var trigger = {};
+      let deffered = this.$q.defer();
+      let trigger = {};
 
       this.HawkularAlert.Trigger.get({triggerId: triggerId}).$promise.then((triggerData) => {
         trigger['trigger'] = triggerData;
@@ -144,7 +144,7 @@ module HawkularMetrics {
 
     public createTrigger(fullTrigger: any, errorCallback: any): ng.IPromise<void> {
 
-      var triggerDefaults = {
+      let triggerDefaults = {
         description: 'Created on ' + Date(),
         firingMatch: 'ALL',
         autoResolveMatch: 'ALL',
@@ -153,14 +153,14 @@ module HawkularMetrics {
         actions: {}
       };
 
-      var trigger = angular.extend(triggerDefaults, fullTrigger.trigger);
+      let trigger = angular.extend(triggerDefaults, fullTrigger.trigger);
 
       return this.HawkularAlert.Trigger.save(trigger).$promise.then((savedTrigger) => {
 
-        var dampeningPromises = [];
-        for (var i = 0; fullTrigger.dampenings && i < fullTrigger.dampenings.length; i++) {
+        let dampeningPromises = [];
+        for (let i = 0; fullTrigger.dampenings && i < fullTrigger.dampenings.length; i++) {
           if (fullTrigger.dampenings[i]) {
-            var dampeningPromise = this.HawkularAlert.Dampening.save({triggerId: savedTrigger.id},
+            let dampeningPromise = this.HawkularAlert.Dampening.save({triggerId: savedTrigger.id},
               fullTrigger.dampenings[i]).$promise.then(null, (error) => {
                 return this.ErrorsManager.errorHandler(error, 'Error creating dampening.', errorCallback);
               });
@@ -168,14 +168,14 @@ module HawkularMetrics {
           }
         }
 
-        var conditionDefaults: any = {
+        let conditionDefaults: any = {
           triggerId: savedTrigger.id
         };
 
-        var conditionPromises = [];
-        for (var j = 0; fullTrigger.conditions && j < fullTrigger.conditions.length; j++) {
+        let conditionPromises = [];
+        for (let j = 0; fullTrigger.conditions && j < fullTrigger.conditions.length; j++) {
           if (fullTrigger.conditions[j]) {
-            var conditionPromise = this.HawkularAlert.Condition.save({triggerId: savedTrigger.id},
+            let conditionPromise = this.HawkularAlert.Condition.save({triggerId: savedTrigger.id},
               fullTrigger.conditions[j]).$promise.then(null, (error) => {
                 return this.ErrorsManager.errorHandler(error, 'Error creating condition.', errorCallback);
               });
@@ -194,7 +194,7 @@ module HawkularMetrics {
 
     public updateTrigger(fullTrigger: any, errorCallback: any, backupTrigger?: any): ng.IPromise<any> {
 
-      var emailPromise = this.addEmailAction(fullTrigger.trigger.actions.email[0]).then(()=> {
+      let emailPromise = this.addEmailAction(fullTrigger.trigger.actions.email[0]).then(()=> {
         if (angular.equals(fullTrigger.trigger, backupTrigger.trigger) || !fullTrigger.trigger) {
           return;
         }
@@ -203,12 +203,12 @@ module HawkularMetrics {
         return this.ErrorsManager.errorHandler(error, 'Error saving email action.', errorCallback);
       });
 
-      var dampeningPromises = [];
-      for (var i = 0; fullTrigger.dampenings && i < fullTrigger.dampenings.length; i++) {
+      let dampeningPromises = [];
+      for (let i = 0; fullTrigger.dampenings && i < fullTrigger.dampenings.length; i++) {
         if (fullTrigger.dampenings[i] && !angular.equals(fullTrigger.dampenings[i], backupTrigger.dampenings[i])) {
-          var triggerId = fullTrigger.trigger.id;
-          var dampeningId = fullTrigger.dampenings[i].dampeningId;
-          var dampeningPromise = this.HawkularAlert.Dampening.put({triggerId: triggerId, dampeningId: dampeningId },
+          let triggerId = fullTrigger.trigger.id;
+          let dampeningId = fullTrigger.dampenings[i].dampeningId;
+          let dampeningPromise = this.HawkularAlert.Dampening.put({triggerId: triggerId, dampeningId: dampeningId },
             fullTrigger.dampenings[i]).$promise.then(null, (error)=> {
               return this.ErrorsManager.errorHandler(error, 'Error saving dampening.', errorCallback);
             });
@@ -217,12 +217,12 @@ module HawkularMetrics {
         }
       }
 
-      var conditionPromises = [];
-      for (var j = 0; fullTrigger.conditions && j < fullTrigger.conditions.length; j++) {
+      let conditionPromises = [];
+      for (let j = 0; fullTrigger.conditions && j < fullTrigger.conditions.length; j++) {
         if (fullTrigger.conditions[j] && !angular.equals(fullTrigger.conditions[j], backupTrigger.conditions[j])) {
-          triggerId = fullTrigger.trigger.id;
-          var conditionId = fullTrigger.conditions[j].conditionId;
-          var conditionPromise =  this.HawkularAlert.Condition.put({triggerId: triggerId,
+          let triggerId = fullTrigger.trigger.id;
+          let conditionId = fullTrigger.conditions[j].conditionId;
+          let conditionPromise =  this.HawkularAlert.Condition.put({triggerId: triggerId,
             conditionId: conditionId}, fullTrigger.conditions[j]).$promise.then(null, (error)=> {
               return this.ErrorsManager.errorHandler(error, 'Error saving condition.', errorCallback);
             });
@@ -276,7 +276,7 @@ module HawkularMetrics {
     }
 
     public setEmail(triggerId:TriggerId, email:EmailType):ng.IPromise<void> {
-      var actions = this.getActions(triggerId);
+      let actions = this.getActions(triggerId);
       return actions.then((actions)=> {
 
         if (!actions) {
@@ -300,8 +300,8 @@ module HawkularMetrics {
     public queryConsoleAlerts(metricId: MetricId, startTime?:TimestampInMillis,
                               endTime?:TimestampInMillis, alertType?:AlertType,
                        currentPage?:number, perPage?:number): any {
-      var alertList = [];
-      var headers;
+      let alertList = [];
+      let headers;
 
       /* Format of Alerts:
 
@@ -315,7 +315,7 @@ module HawkularMetrics {
 
        */
 
-      var queryParams = {
+      let queryParams = {
         statuses:'OPEN'
       };
 
@@ -346,20 +346,20 @@ module HawkularMetrics {
       return this.HawkularAlert.Alert.query(queryParams, (serverAlerts: any, getHeaders: any) => {
 
         headers = getHeaders();
-        var momentNow = this.$moment();
+        let momentNow = this.$moment();
 
-        for (var i = 0; i < serverAlerts.length; i++) {
-          var consoleAlert: any = {};
-          var serverAlert = serverAlerts[i];
+        for (let i = 0; i < serverAlerts.length; i++) {
+          let consoleAlert: any = {};
+          let serverAlert = serverAlerts[i];
 
           consoleAlert.id = serverAlert.alertId;
           consoleAlert.end = serverAlert.ctime;
 
-          var sum: number = 0.0;
-          var count: number = 0.0;
+          let sum: number = 0.0;
+          let count: number = 0.0;
 
-          for (var j = 0; j < serverAlert.evalSets.length; j++) {
-            var evalItem = serverAlert.evalSets[j][0];
+          for (let j = 0; j < serverAlert.evalSets.length; j++) {
+            let evalItem = serverAlert.evalSets[j][0];
 
             if (!consoleAlert.start && evalItem.dataTimestamp) {
               consoleAlert.start = evalItem.dataTimestamp;
@@ -373,7 +373,7 @@ module HawkularMetrics {
               consoleAlert.type = evalItem.condition.type;
             }
 
-            var momentAlert = this.$moment(consoleAlert.end);
+            let momentAlert = this.$moment(consoleAlert.end);
 
             if (momentAlert.year() === momentNow.year()) {
               consoleAlert.isThisYear = true;
@@ -405,8 +405,8 @@ module HawkularMetrics {
 
     public queryAlerts(metricId: MetricId, startTime?:TimestampInMillis, endTime?:TimestampInMillis,
                        currentPage?:number, perPage?:number): any {
-      var alertList = [];
-      var headers;
+      let alertList = [];
+      let headers;
 
       /* Format of Alerts:
 
@@ -420,7 +420,7 @@ module HawkularMetrics {
 
        */
 
-      var queryParams = {
+      let queryParams = {
         statuses:'OPEN'
       };
 
@@ -445,11 +445,11 @@ module HawkularMetrics {
       return this.HawkularAlert.Alert.query(queryParams, (serverAlerts: any, getHeaders: any) => {
 
         headers = getHeaders();
-        var momentNow = this.$moment();
+        let momentNow = this.$moment();
 
-        for (var i = 0; i < serverAlerts.length; i++) {
-          var consoleAlert: any = {};
-          var serverAlert = serverAlerts[i];
+        for (let i = 0; i < serverAlerts.length; i++) {
+          let consoleAlert: any = {};
+          let serverAlert = serverAlerts[i];
 
           consoleAlert.id = serverAlert.alertId;
 
@@ -457,11 +457,11 @@ module HawkularMetrics {
 
           consoleAlert.end = serverAlert.ctime;
 
-          var sum: number = 0.0;
-          var count: number = 0.0;
+          let sum: number = 0.0;
+          let count: number = 0.0;
 
-          for (var j = 0; j < serverAlert.evalSets.length; j++) {
-            var evalItem = serverAlert.evalSets[j][0];
+          for (let j = 0; j < serverAlert.evalSets.length; j++) {
+            let evalItem = serverAlert.evalSets[j][0];
 
             if (!consoleAlert.start && evalItem.dataTimestamp) {
               consoleAlert.start = evalItem.dataTimestamp;
@@ -475,7 +475,7 @@ module HawkularMetrics {
               consoleAlert.type = evalItem.condition.type;
             }
 
-            var momentAlert = this.$moment(consoleAlert.end);
+            let momentAlert = this.$moment(consoleAlert.end);
 
             if (momentAlert.year() === momentNow.year()) {
               consoleAlert.isThisYear = true;


### PR DESCRIPTION
This is a preliminar refactor of alertsManager.ts in order to unify how Alerts API is being used from the UI.
We need to upgrade to Alerts 0.4.x and that has changes on the ui-services, but before to upgrade I think is good trying to simplify and use a consistent way to create triggers and fetch alerts.
There are some parts commented in datasources code as it will be simplify with 0.4.x when we can modify conditions in a single call.
@mtho11 and @jshaughn please, can you take a look ?
If this is ok, then tomorrow we can work upgrading 0.4.x + ui-services and fixing missing things on UI code.