### PR TITLE
HAWKULAR-465 Add Web Tab alert dialog for Sessions

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-web.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-web.html
@@ -28,7 +28,11 @@
     <h3 class="pull-left">
       <button class="btn btn-link hk-trigger" ng-click="showAllAlerts = !showAllAlerts" tooltip-trigger tooltip-placement="top" tooltip="Expand/collapse"><i class="fa" ng-show="vm.alertList.length > 0" ng-class="showAllAlerts ? 'fa-minus-square-o' : 'fa-plus-square-o'"></i> Web Alerts <span ng-show="vm.alertList.length > 0">({{showAllAlerts ? vm.alertList.length : vm.math.min(vm.alertList.length, 3)}} of {{vm.alertList.length}})</span></button>
     </h3>
-    <!--<span class="hk-settings pull-right"><a href="#" ng-controller="MetricsAlertController as mac" ng-click="mac.openSetup()"><i class="fa fa-cog"></i>Alert Settings</a></span>-->
+    <span class="hk-settings pull-right">
+      <a href="#" ng-controller="WebAlertController as wac" ng-click="wac.openSetup()">
+        <i class="fa fa-cog"></i>Web Alert Settings
+      </a>
+    </span>
   </div>
   <div class="clearfix">
     <!-- No Alerts -->
@@ -37,11 +41,9 @@
       <div>No alerts have been fired in this category and time range.</div>
     </div>
     <!-- Alerts exist -->
-    <div class="panel panel-default alert alert-danger" ng-repeat="alert in vm.alertList | limitTo: (showAllAlerts ? 100000 : 3) track by $index">
-      <div class="hk-alert-icon"><i class="fa fa-flag"></i></div>
-      <div class="hk-date">{{alert.evalSets[0][0].evalTimestamp | date:'medium' }}</div>
-      <div class="hk-event"><strong>Alert Summary</strong>: alert details.</div>
-    </div>
+    <!-- Alerts exist -->
+    <hk-alert-panel-list class="clearfix" hk-alert-list="vm.alertList"
+                         hk-limit="(vm.showAllAlerts ? 100000 : 3)"></hk-alert-panel-list>
   </div>
 
 

--- a/console/src/main/scripts/plugins/metrics/html/directives/alert.html
+++ b/console/src/main/scripts/plugins/metrics/html/directives/alert.html
@@ -39,7 +39,16 @@
         <strong>Available Connections</strong>: The number of available connections was {{alert.avg}}.
       </div>
       <div ng-switch-when="DSRESP">
-        <strong>Responsiveness</strong>: The connection {{alert.condition}} was {{alert.avg}}ms.
+        <strong>Responsiveness</strong>: The connection {{alert.condition}} was {{alert.avg}} ms.
+      </div>
+      <div ng-switch-when="ACTIVE_SESSIONS">
+        <strong>Active Web Sessions</strong>: The number of active web sessions was {{alert.avg}}.
+      </div>
+      <div ng-switch-when="EXPIRED_SESSIONS">
+        <strong>Expired Web Sessions</strong>: The number of expired web sessions was {{alert.avg}}.
+      </div>
+      <div ng-switch-when="REJECTED_SESSIONS">
+        <strong>Rejected Web Sessions</strong>: The number of rejected web sessions was {{alert.avg}}.
       </div>
       <div ng-switch-default>
         <strong>Alert</strong>: <code>{{alert}}</code>

--- a/console/src/main/scripts/plugins/metrics/html/modals/alerts-web-setup.html
+++ b/console/src/main/scripts/plugins/metrics/html/modals/alerts-web-setup.html
@@ -1,0 +1,114 @@
+<div class="modal-header">
+  <button type="button" class="close" ng-click="was.cancel()">
+    <span class="pficon pficon-close"></span>
+  </button>
+  <h4 class="modal-title">Web Alert Settings</h4>
+</div>
+<div class="modal-body hk-alert-settings">
+  <tabset>
+    <tab heading="Sessions">
+
+      <div id="hk-heap" class="hk-tab-content">
+        <p>Configure conditions settings for Web Sessions alerts and notifications.</p>
+
+        <form class="form-horizontal">
+          <fieldset>
+            <legend>Active Sessions Thresholds</legend>
+            <div class="form-group">
+              <label class="col-sm-3 control-label" for="active-min">Minimun</label>
+
+              <div class="col-sm-5">
+                <div class="input-group hk-input-small">
+                  <input type="number" min="0" max="10000" ng-model="was.adm.active.activeMinThreshold" class="form-control"
+                         id="active-min" ng-disabled="!was.adm.active.activeMinEnabled">
+
+                </div>
+              </div>
+              <div class="col-sm-4">
+                  <hk-switch hk-model="was.adm.active.activeMinEnabled"
+                             id="active-min-switch" class="pull-right"></hk-switch>
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="col-sm-3 control-label" for="active-max">Maximun</label>
+
+              <div class="col-sm-5">
+                <div class="input-group hk-input-small">
+                  <input type="number" min="0" max="10000" ng-model="was.adm.active.activeMaxThreshold"
+                         class="form-control" id="active-max" ng-disabled="!was.adm.active.activeMaxEnabled">
+
+                </div>
+              </div>
+              <div class="col-sm-4">
+                <hk-switch hk-model="was.adm.active.activeMaxEnabled"
+                           id="active-max-switch" class="pull-right"></hk-switch>
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>Expired Sessions</legend>
+            <div class="form-group">
+              <label class="col-sm-3 control-label" for="expired-threshold">Sessions Exceeding</label>
+
+              <div class="col-sm-5">
+                <div class="input-group hk-input-small">
+                  <input type="number" min="0" max="10000" ng-model="was.adm.expired.expiredThreshold"
+                         class="form-control" id="expired-threshold" ng-disabled="!was.adm.expired.expiredEnabled">
+
+                </div>
+              </div>
+              <div class="col-sm-4">
+                <hk-switch hk-model="was.adm.expired.expiredEnabled"
+                           id="expired-threshold-switch" class="pull-right"></hk-switch>
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>Rejected Sessions</legend>
+            <div class="form-group">
+              <label class="col-sm-3 control-label" for="rejected-threshold">Sessions Exceeding</label>
+
+              <div class="col-sm-5">
+                <div class="input-group hk-input-small">
+                  <input type="number" min="0" max="10000" ng-model="was.adm.rejected.rejectedThreshold"
+                         class="form-control" id="rejected-threshold" ng-disabled="!was.adm.rejected.rejectedEnabled">
+
+                </div>
+              </div>
+              <div class="col-sm-4">
+                <hk-switch hk-model="was.adm.rejected.rejectedEnabled"
+                           id="rejected-threshold-switch" class="pull-right"></hk-switch>
+              </div>
+            </div>
+          </fieldset>
+
+          <hk-fieldset-dampening hk-duration="was.adm.active.responseDuration"
+                                 hk-disabled="!was.adm.active.activeMinEnabled &&
+                                      !was.adm.active.activeMaxEnabled &&
+                                      !was.adm.expired.expiredEnabled &&
+                                      !was.adm.rejected.rejectedEnabled">
+          </hk-fieldset-dampening>
+
+          <hk-fieldset-notification hk-alert-email="was.adm.active.email"
+                                    hk-disabled="!was.adm.active.activeMinEnabled &&
+                                      !was.adm.active.activeMaxEnabled &&
+                                      !was.adm.expired.expiredEnabled &&
+                                      !was.adm.rejected.rejectedEnabled">
+          </hk-fieldset-notification>
+        </form>
+      </div>
+    </tab>
+  </tabset>
+
+
+</div>
+<div class="modal-footer">
+  <button type="button" class="btn btn-default" ng-click="was.cancel()">Cancel</button>
+  <button type="button" class="btn btn-primary" ng-click="was.save()"
+          ng-disabled="was.saveProgress || !was.isSettingChange">
+    <div ng-show="was.saveProgress" class="spinner spinner-xs hk-modal-spinner"></div>
+    Save
+  </button>
+</div>

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebAlerts.ts
@@ -1,0 +1,430 @@
+///
+/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// and other contributors as indicated by the @author tags.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+/// <reference path="../metricsPlugin.ts"/>
+/// <reference path="../../includes.ts"/>
+/// <reference path="../services/alertsManager.ts"/>
+/// <reference path="../services/errorsManager.ts"/>
+
+module HawkularMetrics {
+
+  export class WebAlertController {
+    public static  $inject = ['$scope', 'HawkularAlertsManager', 'ErrorsManager', '$log', '$q',
+      '$rootScope', '$routeParams', '$modal', '$interval', 'HkHeaderParser'];
+
+    private resourceId:string;
+    public alertList:any = [];
+    public defaultEmail:string;
+
+    public isResolvingAll:boolean = false;
+
+    public alertsTimeStart:TimestampInMillis;
+    public alertsTimeEnd:TimestampInMillis;
+    public alertsTimeOffset:TimestampInMillis;
+
+    public resCurPage:number = 0;
+    public resPerPage:number = 5;
+    public headerLinks:any;
+
+    constructor(private $scope:any,
+                private HawkularAlertsManager:IHawkularAlertsManager,
+                private ErrorsManager:IErrorsManager,
+                private $log:ng.ILogService,
+                private $q:ng.IQService,
+                private $rootScope:any,
+                private $routeParams:any,
+                private $modal:any,
+                private $interval:ng.IIntervalService,
+                private HkHeaderParser:any) {
+
+      this.resourceId = $routeParams.resourceId;
+      this.alertsTimeOffset = $routeParams.timeOffset || 3600000;
+      // If the end time is not specified in URL use current time as end time
+      this.alertsTimeEnd = $routeParams.endTime ? $routeParams.endTime : (new Date()).getTime();
+      this.alertsTimeStart = this.alertsTimeEnd - this.alertsTimeOffset;
+
+      this.defaultEmail = this.$rootScope.userDetails.email || 'myemail@company.com';
+
+      this.getAlerts();
+      this.autoRefresh(20);
+    }
+
+    public openSetup():void {
+      // Check if trigger exists on alerts setup modal open. If not, create the trigger before opening the modal
+
+      var defaultEmail = this.$rootScope.userDetails.email || 'myemail@company.com';
+
+      let defaultEmailPromise = this.HawkularAlertsManager.addEmailAction(defaultEmail);
+
+      let activeSessionsTriggerPromise = this.HawkularAlertsManager
+        .existTrigger(this.resourceId + '_web_active_sessions').then(() => {
+        // Active Web Sessions trigger exists, nothing to do
+        this.$log.debug('Active Web Sessions trigger exists, nothing to do');
+      }, () => {
+        // Active Web Sessions trigger doesn't exist, need to create one
+
+        let triggerId:string = this.resourceId + '_web_active_sessions';
+        let resourceId:string = triggerId.slice(0, -20);
+        let dataId:string = 'MI~R~[' + resourceId +
+          '~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions';
+
+        let fullTrigger = {
+          trigger: {
+            name: resourceId,
+            id: triggerId,
+            description: 'Active Web Sessions for ' + resourceId,
+            actions: {email: [this.defaultEmail]},
+            context: {
+              resourceType: 'App Server',
+              resourceName: resourceId
+            }
+          },
+          dampenings: [
+            {
+              triggerId: triggerId,
+              evalTimeSetting: 7 * 60000,
+              triggerMode: 'FIRING',
+              type: 'STRICT_TIME'
+            }
+          ],
+          conditions: [
+            {
+              triggerId: triggerId,
+              type: 'RANGE',
+              dataId: dataId,
+              operatorLow: 'INCLUSIVE',
+              operatorHigh: 'INCLUSIVE',
+              thresholdLow: AppServerWebDetailsController.DEFAULT_MIN_SESSIONS,
+              thresholdHigh: AppServerWebDetailsController.DEFAULT_MAX_SESSIONS,
+              inRange: false,
+              context: {
+                description: 'Active Web Sessions',
+                unit: 'sessions'
+              }
+            }
+          ]
+        };
+
+        return this.HawkularAlertsManager.createTrigger(fullTrigger, () => {
+          this.$log.error('Error on Trigger creation for ' + triggerId);
+        });
+      });
+
+      let expiredSessionsTriggerPromise = this.HawkularAlertsManager
+        .existTrigger(this.resourceId + '_web_expired_sessions').then(() => {
+          // Expired Web Sessions trigger exists, nothing to do
+          this.$log.debug('Expired Web Sessions trigger exists, nothing to do');
+        }, () => {
+          // Active Web Sessions trigger doesn't exist, need to create one
+
+          let triggerId:string = this.resourceId + '_web_expired_sessions';
+          let resourceId:string = triggerId.slice(0, -21);
+          let dataId:string = 'MI~R~[' + resourceId +
+            '~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions';
+
+          let fullTrigger = {
+            trigger: {
+              name: resourceId,
+              id: triggerId,
+              description: 'Expired Web Sessions for ' + resourceId,
+              actions: {email: [this.defaultEmail]},
+              context: {
+                resourceType: 'App Server',
+                resourceName: resourceId
+              }
+            },
+            dampenings: [
+              {
+                triggerId: triggerId,
+                evalTimeSetting: 7 * 60000,
+                triggerMode: 'FIRING',
+                type: 'STRICT_TIME'
+              }
+            ],
+            conditions: [
+              {
+                triggerId: triggerId,
+                type: 'THRESHOLD',
+                dataId: dataId,
+                threshold: AppServerWebDetailsController.DEFAULT_EXPIRED_SESSIONS_THRESHOLD,
+                operator: 'GT',
+                context: {
+                  description: 'Expired Web Sessions',
+                  unit: 'sessions'
+                }
+              }
+            ]
+          };
+
+          return this.HawkularAlertsManager.createTrigger(fullTrigger, () => {
+            this.$log.error('Error on Trigger creation for ' + triggerId);
+          });
+        });
+
+
+      let rejectedSessionsTriggerPromise = this.HawkularAlertsManager
+        .existTrigger(this.resourceId + '_web_rejected_sessions').then(() => {
+          // Web Sessions trigger exists, nothing to do
+          this.$log.debug('Rejected Web Sessions trigger exists, nothing to do');
+        }, () => {
+          // Rejected Web Sessions trigger doesn't exist, need to create one
+
+          let triggerId:string = this.resourceId + '_web_rejected_sessions';
+          let resourceId:string = triggerId.slice(0, -22);
+          let dataId:string = 'MI~R~[' + resourceId +
+            '~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions';
+
+          let fullTrigger = {
+            trigger: {
+              name: resourceId,
+              id: triggerId,
+              description: 'Rejected Web Sessions for ' + resourceId,
+              actions: {email: [this.defaultEmail]},
+              context: {
+                resourceType: 'App Server',
+                resourceName: resourceId
+              }
+            },
+            dampenings: [
+              {
+                triggerId: triggerId,
+                evalTimeSetting: 7 * 60000,
+                triggerMode: 'FIRING',
+                type: 'STRICT_TIME'
+              }
+            ],
+            conditions: [
+              {
+                triggerId: triggerId,
+                type: 'THRESHOLD',
+                dataId: dataId,
+                threshold: AppServerWebDetailsController.DEFAULT_REJECTED_SESSIONS_THRESHOLD,
+                operator: 'GT',
+                context: {
+                  description: 'Rejected Web Sessions',
+                  unit: 'sessions'
+                }
+              }
+            ]
+          };
+
+          return this.HawkularAlertsManager.createTrigger(fullTrigger, () => {
+            this.$log.error('Error on Trigger creation for ' + triggerId);
+          });
+        });
+
+      let log = this.$log;
+
+      this.$q.all([defaultEmailPromise, activeSessionsTriggerPromise, expiredSessionsTriggerPromise,
+        rejectedSessionsTriggerPromise]).then(() => {
+        let modalInstance = this.$modal.open({
+          templateUrl: 'plugins/metrics/html/modals/alerts-web-setup.html',
+          controller: 'WebAlertSetupController as was',
+          resolve: {
+            resourceId: () => {
+              return this.resourceId;
+            }
+          }
+        });
+
+        modalInstance.result.then(angular.noop, () => {
+          log.debug('Web Alert Setup modal dismissed at: ' + new Date());
+        });
+      }, () => {
+        this.$log.error('Missing and unable to create new Web Alert triggers.');
+      });
+
+    }
+
+    private autoRefresh(intervalInSeconds:number):void {
+      let autoRefreshPromise = this.$interval(()  => {
+        this.getAlerts();
+      }, intervalInSeconds * 1000);
+
+      this.$scope.$on('$destroy', () => {
+        this.$interval.cancel(autoRefreshPromise);
+      });
+    }
+
+    public getAlerts():void {
+      // Done in appServerWebDetails.ts#getAlerts()
+    }
+
+    public setPage(page:number):void {
+      this.resCurPage = page;
+      this.getAlerts();
+    }
+
+    public resolveAll():void {
+      this.isResolvingAll = true;
+      let alertIdList = '';
+      for (let i = 0; i < this.alertList.length; i++) {
+        alertIdList = alertIdList + this.alertList[i].id + ',';
+      }
+      alertIdList = alertIdList.slice(0, -1);
+
+      let resolvedAlerts = {
+        alertIds: alertIdList,
+        resolvedBy: this.$rootScope.currentPersona.name,
+        resolvedNotes: 'Manually resolved'
+      };
+
+      this.HawkularAlertsManager.resolveAlerts(resolvedAlerts).then(() => {
+        this.alertList.length = 0;
+        this.isResolvingAll = false;
+      });
+    }
+  }
+
+  _module.controller('WebAlertController', WebAlertController);
+
+  export class WebAlertSetupController extends AlertSetupController {
+
+    public maxUsage:number = AppServerWebDetailsController.MAX_SESSIONS;
+
+    loadTriggers():Array<ng.IPromise<any>> {
+
+      let activeSessionsTriggerId:string = this.$routeParams.resourceId + '_web_active_sessions';
+
+      let activeSessionsTriggerPromise = this.HawkularAlertsManager.getTrigger(activeSessionsTriggerId).then(
+        (triggerData) => {
+          this.triggerDefinition['active'] = triggerData;
+
+          this.adm.active = {};
+          this.adm.active['email'] = triggerData.trigger.actions.email[0];
+          this.adm.active['responseDuration'] = triggerData.dampenings[0].evalTimeSetting;
+
+          this.adm.active['activeMaxEnabled'] = false;
+          this.adm.active['activeMaxThreshold'] = AppServerWebDetailsController.DEFAULT_MAX_SESSIONS;
+
+          this.adm.active['activeMinEnabled'] = false;
+          this.adm.active['activeMinThreshold'] = AppServerWebDetailsController.DEFAULT_MIN_SESSIONS;
+
+          if (triggerData.conditions[0].context.description === 'Active Web Sessions') {
+            this.adm.active['activeMaxEnabled'] = triggerData.conditions[0].thresholdHigh < this.maxUsage;
+            this.adm.active['activeMaxThreshold'] = triggerData.conditions[0].thresholdHigh;
+            this.adm.active['activeMinEnabled'] = triggerData.conditions[0].thresholdLow > 0;
+            this.adm.active['activeMinThreshold'] = triggerData.conditions[0].thresholdLow;
+          }
+
+          if (!triggerData.trigger.enabled) {
+            this.adm.active['activeMaxEnabled'] = false;
+            this.adm.active['activeMinEnabled'] = false;
+          }
+
+        });
+
+      let expiredSessionsTriggerId:string = this.$routeParams.resourceId + '_web_expired_sessions';
+
+      let expiredSessionsTriggerPromise = this.HawkularAlertsManager.getTrigger(expiredSessionsTriggerId).then(
+        (triggerData) => {
+          this.triggerDefinition['expired'] = triggerData;
+
+          this.adm.expired = {};
+
+          // Dampening and Notification will be shared from the active threshold
+
+          this.adm.expired['expiredEnabled'] = triggerData.trigger.enabled;;
+          this.adm.expired['expiredThreshold'] = AppServerWebDetailsController.DEFAULT_EXPIRED_SESSIONS_THRESHOLD;
+
+          if (triggerData.conditions[0].context.description === 'Expired Web Sessions') {
+            this.adm.expired['expiredThreshold'] = triggerData.conditions[0].threshold;
+          }
+
+        });
+
+      let rejectedSessionsTriggerId:string = this.$routeParams.resourceId + '_web_rejected_sessions';
+
+      let rejectedSessionsTriggerPromise = this.HawkularAlertsManager.getTrigger(rejectedSessionsTriggerId).then(
+        (triggerData) => {
+          this.triggerDefinition['rejected'] = triggerData;
+
+          this.adm.rejected = {};
+
+          // Dampening and Notification will be shared from the active threshold
+
+          this.adm.rejected['rejectedEnabled'] = triggerData.trigger.enabled;;
+          this.adm.rejected['rejectedThreshold'] = AppServerWebDetailsController.DEFAULT_REJECTED_SESSIONS_THRESHOLD;
+
+          if (triggerData.conditions[0].context.description === 'Rejected Web Sessions') {
+            this.adm.rejected['rejectedThreshold'] = triggerData.conditions[0].threshold;
+          }
+
+        });
+
+      return [activeSessionsTriggerPromise,expiredSessionsTriggerPromise,rejectedSessionsTriggerPromise];
+    }
+
+    saveTriggers(errorCallback):Array<ng.IPromise<any>> {
+
+      let activeSessionsTrigger = angular.copy(this.triggerDefinition.active);
+      activeSessionsTrigger.trigger.actions.email[0] = this.adm.active.email;
+      activeSessionsTrigger.dampenings[0].evalTimeSetting = this.adm.active.responseDuration;
+
+      activeSessionsTrigger.trigger.enabled = true;
+      if (this.adm.active['activeMaxEnabled'] && this.adm.active['activeMinEnabled']) {
+        activeSessionsTrigger.conditions[0].thresholdLow = this.adm.active['activeMinThreshold'];
+        activeSessionsTrigger.conditions[0].thresholdHigh = this.adm.active['activeMaxThreshold'];
+      } else if (!this.adm.active['activeMaxEnabled'] && this.adm.active['activeMinEnabled']) {
+        activeSessionsTrigger.conditions[0].thresholdLow = this.adm.active['activeMinThreshold'];
+        activeSessionsTrigger.conditions[0].thresholdHigh = AppServerWebDetailsController.DEFAULT_MAX_SESSIONS;
+      } else if (this.adm.active['activeMaxEnabled'] && !this.adm.active['activeMinEnabled']) {
+        activeSessionsTrigger.conditions[0].thresholdLow = 0;
+        activeSessionsTrigger.conditions[0].thresholdHigh = this.adm.active['activeMaxThreshold'];
+      } else {
+        activeSessionsTrigger.trigger.enabled = false;
+      }
+
+      let activeSessionsSavePromise = this.HawkularAlertsManager.updateTrigger(activeSessionsTrigger, errorCallback,
+        this.triggerDefinition.active);
+
+
+      let expiredSessionsTrigger = angular.copy(this.triggerDefinition.expired);
+      expiredSessionsTrigger.trigger.actions.email[0] = this.adm.active.email;
+      expiredSessionsTrigger.dampenings[0].evalTimeSetting = this.adm.active.responseDuration;
+
+      expiredSessionsTrigger.trigger.enabled = true;
+      if (this.adm.expired['expiredEnabled']) {
+        expiredSessionsTrigger.conditions[0].threshold = this.adm.expired['expiredThreshold'];
+      } else {
+        expiredSessionsTrigger.trigger.enabled = false;
+      }
+
+      let expiredSessionsSavePromise = this.HawkularAlertsManager.updateTrigger(expiredSessionsTrigger, errorCallback,
+        this.triggerDefinition.expired);
+
+
+      let rejectedSessionsTrigger = angular.copy(this.triggerDefinition.rejected);
+      rejectedSessionsTrigger.trigger.actions.email[0] = this.adm.active.email;
+      rejectedSessionsTrigger.dampenings[0].evalTimeSetting = this.adm.active.responseDuration;
+
+      rejectedSessionsTrigger.trigger.enabled = true;
+      if (this.adm.rejected['rejectedEnabled']) {
+        rejectedSessionsTrigger.conditions[0].threshold = this.adm.rejected['rejectedThreshold'];
+      } else {
+        rejectedSessionsTrigger.trigger.enabled = false;
+      }
+
+      let rejectedSessionsSavePromise = this.HawkularAlertsManager.updateTrigger(rejectedSessionsTrigger, errorCallback,
+        this.triggerDefinition.rejected);
+
+      return [activeSessionsSavePromise,expiredSessionsSavePromise,rejectedSessionsSavePromise];
+    }
+  }
+
+  _module.controller('WebAlertSetupController', WebAlertSetupController);
+}

--- a/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
@@ -220,6 +220,8 @@ module HawkularMetrics {
 
           consoleAlert.id = serverAlert.alertId;
 
+          consoleAlert.triggerId = serverAlert.triggerId;
+
           consoleAlert.dataId = serverAlert.evalSets[0][0].condition.dataId;
 
           consoleAlert.end = serverAlert.ctime;


### PR DESCRIPTION
This PR is focus on the Web Session metrics, as those are present in the page.
The original JIRA covers also Container Threads and Requests which are not shown.
So, I decided to support only alerts with visible metrics.
Please @mtho11 and @jshaughn take a look at this work and merge if you think is correct.
