### PR TITLE
HWKALERTS-77 Add resourcePath into Trigger.context

### DIFF
--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesAlerts.ts
@@ -115,8 +115,6 @@ module HawkularMetrics {
         respUpdateConditions = [
           {
             triggerId: respTriggerId,
-            conditionSetSize: 1,
-            conditionSetIndex: 1,
             type: 'THRESHOLD',
             dataId: dataId1,
             threshold: this.adm.resp.waitTimeThreshold,
@@ -131,8 +129,6 @@ module HawkularMetrics {
         respUpdateConditions = [
           {
             triggerId: respTriggerId,
-            conditionSetSize: 1,
-            conditionSetIndex: 1,
             type: 'THRESHOLD',
             dataId: dataId2,
             threshold: this.adm.resp.creationTimeThreshold,
@@ -147,8 +143,6 @@ module HawkularMetrics {
         respUpdateConditions = [
           {
             triggerId: respTriggerId,
-            conditionSetSize: 2,
-            conditionSetIndex: 1,
             type: 'THRESHOLD',
             dataId: dataId1,
             threshold: this.adm.resp.waitTimeThreshold,
@@ -160,8 +154,6 @@ module HawkularMetrics {
           },
           {
             triggerId: respTriggerId,
-            conditionSetSize: 2,
-            conditionSetIndex: 2,
             type: 'THRESHOLD',
             dataId: dataId2,
             threshold: this.adm.resp.creationTimeThreshold,

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesDetails.ts
@@ -126,7 +126,8 @@ module HawkularMetrics {
             actions: {email: [this.defaultEmail]},
             context: {
               resourceType: 'DataSource',
-              resourceName: resId
+              resourceName: resId,
+              resourcePath: this.$rootScope.resourcePath
             }
           },
           dampenings: [
@@ -191,8 +192,6 @@ module HawkularMetrics {
           conditions: [
             {
               triggerId: triggerId,
-              conditionSetSize: 2,
-              conditionSetIndex: 1,
               type: 'THRESHOLD',
               dataId: dataId1,
               threshold: AppServerDatasourcesDetailsController.DEFAULT_WAIT_THRESHOLD,
@@ -204,8 +203,6 @@ module HawkularMetrics {
             },
             {
               triggerId: triggerId,
-              conditionSetSize: 2,
-              conditionSetIndex: 2,
               type: 'THRESHOLD',
               dataId: dataId2,
               threshold: AppServerDatasourcesDetailsController.DEFAULT_CREA_THRESHOLD,

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmAlerts.ts
@@ -86,7 +86,8 @@ module HawkularMetrics {
             actions: {email: [this.defaultEmail]},
             context: {
               resourceType: 'App Server',
-              resourceName: resourceId
+              resourceName: resourceId,
+              resourcePath: this.$rootScope.resourcePath
             }
           },
           dampenings: [
@@ -139,7 +140,8 @@ module HawkularMetrics {
             actions: {email: [this.defaultEmail]},
             context: {
               resourceType: 'App Server',
-              resourceName: resourceId
+              resourceName: resourceId,
+              resourcePath: this.$rootScope.resourcePath
             }
           },
           dampenings: [
@@ -189,7 +191,8 @@ module HawkularMetrics {
             actions: {email: [this.defaultEmail]},
             context: {
               resourceType: 'App Server',
-              resourceName: resourceId
+              resourceName: resourceId,
+              resourcePath: this.$rootScope.resourcePath
             }
           },
           dampenings: [

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebAlerts.ts
@@ -90,7 +90,8 @@ module HawkularMetrics {
             actions: {email: [this.defaultEmail]},
             context: {
               resourceType: 'App Server',
-              resourceName: resourceId
+              resourceName: resourceId,
+              resourcePath: this.$rootScope.resourcePath
             }
           },
           dampenings: [
@@ -144,7 +145,8 @@ module HawkularMetrics {
               actions: {email: [this.defaultEmail]},
               context: {
                 resourceType: 'App Server',
-                resourceName: resourceId
+                resourceName: resourceId,
+                resourcePath: this.$rootScope.resourcePath
               }
             },
             dampenings: [
@@ -196,7 +198,8 @@ module HawkularMetrics {
               actions: {email: [this.defaultEmail]},
               context: {
                 resourceType: 'App Server',
-                resourceName: resourceId
+                resourceName: resourceId,
+                resourcePath: this.$rootScope.resourcePath
               }
             },
             dampenings: [

--- a/console/src/main/scripts/plugins/metrics/ts/metricsAppServerDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsAppServerDetails.ts
@@ -50,6 +50,7 @@ module HawkularMetrics {
         resourcePath: this.$routeParams.resourceId + '~~'
       }, (resource:IResourcePath) => {
         this.resourcePath = resource.path;
+        this.$rootScope.resourcePath = this.resourcePath;
       });
 
       $scope.tabs = this;

--- a/console/src/main/scripts/plugins/metrics/ts/urlList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/urlList.ts
@@ -152,6 +152,7 @@ module HawkularMetrics {
       var defaultEmail = this.$rootScope.userDetails.email || 'myemail@company.com';
       var err = (error:any, msg:string):void => this.ErrorsManager.errorHandler(error, msg);
       var currentTenantId:TenantId = this.$rootScope.currentPersona.id;
+      var resourcePath :string;
 
       /// Add the Resource and its metrics
       this.HawkularInventory.Resource.save({environmentId: globalEnvironmentId}, resource).$promise
@@ -200,6 +201,14 @@ module HawkularMetrics {
 
         // Create threshold trigger for newly created metrics
         .then(() => {
+
+          for (let i=0; i < this.resourceList.length; i++) {
+            if (metricId === this.resourceList[i].id) {
+              resourcePath = this.resourceList[i].path;
+              break;
+            }
+          }
+
           var triggerId = metricId + '_trigger_thres';
           var dataId: string = triggerId.slice(0,-14) + '.status.duration';
           var fullTrigger = {
@@ -210,7 +219,8 @@ module HawkularMetrics {
               actions: {email: [defaultEmail]},
               context: {
                 resourceType: 'URL',
-                resourceName: url
+                resourceName: url,
+                resourcePath: resourcePath
               }
             },
             dampenings: [
@@ -271,7 +281,8 @@ module HawkularMetrics {
               actions: {email: [defaultEmail]},
               context: {
                 resourceType: 'URL',
-                resourceName: url
+                resourceName: url,
+                resourcePath: resourcePath
               }
             },
             dampenings: [


### PR DESCRIPTION
Triggers and Conditions contexts are designed to be used at client level, so any additional field can be added easily there, as it doesn't affect into the alerts inference process.
please, @mtho11 take a look to see if it suits your requeriments for Alert Center API.