### PR TITLE
Fix Deployment file name cleaning

### DIFF
--- a/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDeploymentsAddDialog.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDeploymentsAddDialog.ts
@@ -103,7 +103,7 @@ module HawkularMetrics {
     }
 
     private cleanFilePath(filePath:string):string {
-      return filePath.substr(12, filePath.length - 1);
+      return filePath.replace('C:\\fakepath\\','');
     }
 
     public onClose():void {


### PR DESCRIPTION
Not all browsers append the "C:\fakepath\" and, for those who appended
if going back and forth, filename was getting cut by 12 chars every time