### PR TITLE
HAWKULAR-629 Upgrade to the new embedded Cassandra version (without log conflicts)

### DIFF
--- a/dist/src/main/resources/wildfly/patches/standalone.xsl
+++ b/dist/src/main/resources/wildfly/patches/standalone.xsl
@@ -126,11 +126,6 @@
         <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.liquibase:WARN}</xsl:text></xsl:attribute>
       </level>
     </logger>
-    <logger category="org.apache.cassandra">
-      <level>
-        <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.cassandra:WARN}</xsl:text></xsl:attribute>
-      </level>
-    </logger>
     <logger category="org.jboss.as.ejb3">
       <level>
         <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.ejb3:WARN}</xsl:text></xsl:attribute>

--- a/modules/end-to-end-test/pom.xml
+++ b/modules/end-to-end-test/pom.xml
@@ -103,7 +103,6 @@
         <hawkular.log.nest>INFO</hawkular.log.nest>
         <hawkular.log.datastax.driver>INFO</hawkular.log.datastax.driver>
         <hawkular.log.liquibase>WARN</hawkular.log.liquibase>
-        <hawkular.log.cassandra>INFO</hawkular.log.cassandra>
         <hawkular.log.ejb3>WARN</hawkular.log.ejb3>
         <hawkular.log.rewrite>WARN</hawkular.log.rewrite>
         <http.log>ERROR</http.log>
@@ -178,7 +177,6 @@
                 <javaOpt>-Dhawkular.log.nest=${hawkular.log.nest}</javaOpt>
                 <javaOpt>-Dhawkular.log.datastax.driver=${hawkular.log.datastax.driver}</javaOpt>
                 <javaOpt>-Dhawkular.log.liquibase=${hawkular.log.liquibase}</javaOpt>
-                <javaOpt>-Dhawkular.log.cassandra=${hawkular.log.cassandra}</javaOpt>
                 <javaOpt>-Dhawkular.log.ejb3=${hawkular.log.ejb3}</javaOpt>
                 <javaOpt>-Dhawkular.log.rewrite=${hawkular.log.rewrite}</javaOpt>
                 <javaOpt>-Dhawkular.log.rewrite=${hawkular.log.rewrite}</javaOpt>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,6 @@
     <version>24</version>
   </parent>
 
-  <groupId>org.hawkular</groupId>
   <artifactId>hawkular</artifactId>
   <!-- Important a released version should always follow any of these patterns: -->
   <!-- major.minor.micro.Alpha[n] -->
@@ -88,7 +87,7 @@
     <version.org.hawkular.agent>0.9.0.Final</version.org.hawkular.agent>
     <version.org.hawkular.alerts>0.4.1.Final</version.org.hawkular.alerts>
     <version.org.hawkular.bus>0.6.1.Final</version.org.hawkular.bus>
-    <version.org.hawkular.commons>0.2.1.Final</version.org.hawkular.commons>
+    <version.org.hawkular.commons>0.2.2.Final-SRC-revision-2f649e10df3c4b25557cf9ae5c77da7f9ef77619</version.org.hawkular.commons>
     <version.org.hawkular.cmdgw>0.8.0.Final</version.org.hawkular.cmdgw>
     <version.org.hawkular.metrics>0.5.0.Final</version.org.hawkular.metrics>
     <version.org.hawkular.inventory>0.3.3.Final</version.org.hawkular.inventory>


### PR DESCRIPTION
Updated version property (with srcdep)

Also, removed the "org.apache.cassandra" logger definitions (no longer needed)