### PR TITLE
HAWKULAR-596 : Improved counter/rate data at GC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <version.org.hawkular.bus>0.6.1.Final</version.org.hawkular.bus>
     <version.org.hawkular.commons>0.2.2.Final-SRC-revision-2f649e10df3c4b25557cf9ae5c77da7f9ef77619</version.org.hawkular.commons>
     <version.org.hawkular.cmdgw>0.8.0.Final</version.org.hawkular.cmdgw>
-    <version.org.hawkular.metrics>0.5.0.Final</version.org.hawkular.metrics>
+    <version.org.hawkular.metrics>0.6.0.Final</version.org.hawkular.metrics>
     <version.org.hawkular.inventory>0.3.3.Final</version.org.hawkular.inventory>
     <version.org.hawkular.nest>${version.org.hawkular.bus}</version.org.hawkular.nest>
     <version.org.keycloak>1.3.1.Final</version.org.keycloak>


### PR DESCRIPTION
Populating missing data (for start and in the middle) with 0 values so
that time range and generated buckets are good.

Also upgraded to Hawkular Metrics 0.6.0.Final