### PR TITLE
Bump alerts to 0.5.x using srcdeps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <version.gnu.getopt>1.0.13</version.gnu.getopt>
     <version.org.hawkular.accounts>1.0.16.Final-SRC-revision-a4578872c091411501d6bd528737c7f2b0902291</version.org.hawkular.accounts>
     <version.org.hawkular.agent>0.10.0.Final</version.org.hawkular.agent>
-    <version.org.hawkular.alerts>0.4.1.Final</version.org.hawkular.alerts>
+    <version.org.hawkular.alerts>0.5.0.Final-SRC-revision-4b0914c22cc1bf101b339149daa6f52aa383634f</version.org.hawkular.alerts>
     <version.org.hawkular.bus>0.7.0.Final</version.org.hawkular.bus>
     <version.org.hawkular.commons>0.2.2.Final-SRC-revision-1a725b961ec22eee5a81375aff4c016c73cd95e4</version.org.hawkular.commons>
     <version.org.hawkular.cmdgw>0.9.0.Final</version.org.hawkular.cmdgw>


### PR DESCRIPTION
With the upgrade of bus v0.7.0 alerts needed to be aligned and use same API.
I've upgraded into 0.5.x and using srcdeps to point specific commit as we have not finished the 0.5.0 version yet.