### PR TITLE
HAWKULAR-680 and organizations improvements

### DIFF
--- a/console/src/main/scripts/plugins/accounts/html/organization-accept-invitation.html
+++ b/console/src/main/scripts/plugins/accounts/html/organization-accept-invitation.html
@@ -1,34 +1,39 @@
-<div class="row">
-  <div class="col-md-12" ng-controller="HawkularAccounts.InvitationController as controller">
-    <ol class="breadcrumb">
-      <li><a data-ng-href="/hawkular-ui/organizations">&laquo; All organizations</a></li>
-    </ol>
+<div ng-controller="HawkularAccounts.InvitationController as controller">
 
-    <h1 class="text-center" ng-show="controller.success">Invitation for {{controller.invitation.organization.name}}</h1>
-    <h1 class="text-center" ng-show="!controller.success">Invitation</h1>
-
-    <div class="progress-description" ng-show="controller.loading">
-      <div class="spinner spinner-xs spinner-inline"></div>
-      <strong>Loading:</strong> processing invitation
+  <div class="hk-screen-top-nav">
+    <div class="row hk-top-row" >
+      <div class="col-xs-6" ng-show="!controller.loading">
+        <a data-ng-href="/hawkular-ui/organizations">&laquo; All organizations</a>
+      </div>
     </div>
-
-    <div class="row text-center" ng-show="!controller.loading && controller.success">
-      <i class="fa fa-users" id="accepted-invitation-icon"></i>
-      <h2>Invitation accepted</h2>
-      <p>
-        You can now use Hawkular as {{controller.invitation.organization.name}}. To do that, just select
-        '{{controller.invitation.organization.name}}' from the account switcher, on the top-right corner of this screen.
-      </p>
+    <div class="hk-heading">
+      <h1 ng-show="controller.success">Invitation for {{controller.invitation.organization.name}}</h1>
+      <h1 ng-show="!controller.success">Invitation</h1>
     </div>
-
-    <div class="row text-center" ng-show="!controller.loading && !controller.success">
-      <i class="fa fa-users" id="error-accepted-invitation-icon"></i>
-      <h2>Error</h2>
-      <p>
-        Something went wrong while processing your invitation.
-      </p>
-    </div>
-
   </div>
-  <!-- /col -->
+
+  <div class="text-center hk-spinner-container-alone" ng-show="controller.loading">
+    <div class="spinner spinner-lg"></div>
+    <p class="hk-spinner-legend-below">Loading...</p>
+  </div>
+
+  <div class="blank-slate-pf" ng-show="!controller.loading && controller.success">
+    <div class="blank-slate-pf-icon">
+      <i class="fa fa-users" id="accepted-invitation-icon"></i>
+    </div>
+    <h1>Invitation accepted</h1>
+    <p>
+      You can now use Hawkular as {{controller.invitation.organization.name}}. To do that, select
+      '{{controller.invitation.organization.name}}' in the account switcher.
+    </p>
+  </div>
+
+  <div class="blank-slate-pf" ng-show="!controller.loading && !controller.success">
+    <div class="blank-slate-pf-icon">
+      <i class="fa fa-meh-o" id="error-accepted-invitation-icon"></i>
+    </div>
+    <h1>Something went wrong while processing your invitation.</h1>
+    </p>
+  </div>
+
 </div>

--- a/console/src/main/scripts/plugins/accounts/html/organizations.html
+++ b/console/src/main/scripts/plugins/accounts/html/organizations.html
@@ -55,7 +55,7 @@
                     class="btn btn-link"
                     tooltip-trigger
                     tooltip-placement="top"
-                    tooltip="Remove"
+                    tooltip="Delete"
                     ng-click="remove(organization)">
               <i class="fa fa-trash-o"></i>
             </button>

--- a/console/src/main/scripts/plugins/accounts/less/accounts.less
+++ b/console/src/main/scripts/plugins/accounts/less/accounts.less
@@ -44,27 +44,25 @@ body.inactivity-modal-open #main, body.inactivity-modal-open .navbar, body.inact
   filter: blur(5px);
 }
 
-#empty-organizations-icon,
-#empty-organizations-icon-for-organizations,
-#accepted-invitation-icon,
-#error-accepted-invitation-icon,
-#organization-not-found-icon {
-  color: @gray-light;
-  font-size: ceil(@font-size-base * 4);
+
+// User dropdown
+
+#personaSwitcher {
+
+  .hk-using {
+    padding: 7px 15px 5px 15px;
+  }
+
+  .fa-check {
+    font-size: 14px;
+    vertical-align: text-bottom;
+  }
+
+  .active .fa-check {
+    color: white;
+  }
 }
 
-.selected-persona, .selected-persona .fa {
-  .bg-primary;
-  color: #fff !important;
-}
-
-.selected-persona:hover, .selected-persona:hover .fa {
-  color: #333 !important;
-}
-
-.icon-invisible {
-  visibility: hidden;
-}
 
 /*------------------------------------*\
     SCREENS

--- a/console/src/main/scripts/plugins/accounts/ts/invitation.ts
+++ b/console/src/main/scripts/plugins/accounts/ts/invitation.ts
@@ -43,7 +43,7 @@ module HawkularAccounts {
         (error:IErrorPayload) => {
           this.success = false;
           this.loading = false;
-          this.NotificationsService.warning(`An error occurred while processing the invitation: ${error.data.message}`);
+          this.NotificationsService.error(`Error: ${error.data.message}`);
           this.$log.debug(`Error while trying to process the invitation: ${error.data.message}`);
         }
       );

--- a/console/src/main/scripts/plugins/accounts/ts/organizationMembership.ts
+++ b/console/src/main/scripts/plugins/accounts/ts/organizationMembership.ts
@@ -248,7 +248,7 @@ module HawkularAccounts {
 
     public transferOwnership(membership:IOrganizationMembership):void {
       if (!this.isAllowedToTransferOrganization) {
-        this.NotificationsService.error('You don\'t have the permissions to transfer this organization.');
+        this.NotificationsService.error('Error: You don\'t have the permissions to transfer this organization.');
         return;
       }
 
@@ -303,7 +303,7 @@ module HawkularAccounts {
 
     public invite():void {
       this.invitation.$save(() => {
-        this.NotificationsService.info('Your invitation was submitted.');
+        this.NotificationsService.success('Invitation successfully sent.');
         this.$modalInstance.close(
           this.invitation.emails
             .split(/[,\s]/)
@@ -313,7 +313,7 @@ module HawkularAccounts {
           )
         );
       }, (error:IErrorPayload) => {
-        this.NotificationsService.warning('An error occurred while trying to send the invitations.');
+        this.NotificationsService.error('An error occurred while trying to send the invitations.');
         this.$log.debug(`Error while trying to send invitations: ${error.data.message}`);
         this.$modalInstance.close('error');
       });

--- a/console/src/main/scripts/plugins/accounts/ts/organizations.ts
+++ b/console/src/main/scripts/plugins/accounts/ts/organizations.ts
@@ -55,7 +55,7 @@ module HawkularAccounts {
         });
 
         createFormModal.result.then((organization) =>  {
-          NotificationsService.success(`Organization successfully created`);
+          NotificationsService.success(`Organization successfully created.`);
           $scope.organizations.unshift(organization);
         }, (type, error) => {
           if (type === 'error') {
@@ -79,11 +79,11 @@ module HawkularAccounts {
         removeOrgModal.result.then(() => {
           organization.$remove().then(
             () => {
-              NotificationsService.success(`Organization successfully deleted`);
+              NotificationsService.success(`Organization successfully deleted.`);
               $scope.$emit('OrganizationRemoved');
               $scope.organizations.splice($scope.organizations.indexOf(organization), 1);
             }, (error) => {
-              $log.warn('Error while trying to remove organization');
+              $log.warn('Error while trying to remove organization.');
               $log.warn(error);
               let message = error.data.message;
               NotificationsService.error(`Failed to remove the organization ${organization.name}: ${message}`);

--- a/console/src/main/scripts/plugins/accounts/ts/persona.ts
+++ b/console/src/main/scripts/plugins/accounts/ts/persona.ts
@@ -34,7 +34,7 @@ module HawkularAccounts {
             $scope.$emit('CurrentPersonaLoaded', $scope.currentPersona);
           },
           () => {
-            NotificationsService.error('Failed in retrieving the current persona.');
+            NotificationsService.error('Error: Failed in retrieving the current persona.');
             $log.warn('Failed in retrieving the current persona');
           }
         );
@@ -46,7 +46,7 @@ module HawkularAccounts {
             $scope.loading = false;
           },
           () => {
-            NotificationsService.error('List of personas could NOT be retrieved.');
+            NotificationsService.error('Error: List of personas could NOT be retrieved.');
             $log.warn('List of personas could NOT be retrieved.');
             $scope.loading = false;
           }

--- a/console/src/main/scripts/plugins/metrics/less/metrics.less
+++ b/console/src/main/scripts/plugins/metrics/less/metrics.less
@@ -125,10 +125,6 @@ a:hover {
   margin-top: @grid-gutter-width*5.5;
 }
 
-.hk-bold {
-  font-weight: bold;
-}
-
 .btn + .btn {
   margin-left: @grid-gutter-width/8;
 }
@@ -142,6 +138,14 @@ a:hover {
   > div {
     display: table-cell;
   }
+}
+
+.hk-bold {
+  font-weight: bold;
+}
+
+.hk-invisible {
+  visibility: hidden;
 }
 
 

--- a/console/src/main/webapp/index.html
+++ b/console/src/main/webapp/index.html
@@ -63,13 +63,13 @@
                 {{currentPersona.name}} <b class="caret"></b>
               </a>
               <ul class="dropdown-menu" id="personaSwitcher">
-                <li class="text-muted">Use Hawkular as:</li>
+                <li class="text-muted hk-using">Use Hawkular as:</li>
                 <li ng-repeat="persona in personas">
                   <a
                           href="#"
                           ng-click="switchPersona(persona)"
                           ng-class="{'selected-persona': persona.id === currentPersona.id}">
-                    <i class="fa fa-check" ng-class="{'icon-invisible': persona.id !== currentPersona.id}"></i>
+                    <i class="fa fa-check" ng-class="{'hk-invisible': persona.id !== currentPersona.id}"></i>
                     {{persona.name}}
                   </a>
                 </li>


### PR DESCRIPTION
Refined:
- Account switch 
- Accept invitation screen
- Feedback messages

Pending, for Juraci:
- When changing user role: show feedback success via toastr "User role successfully changed." Thus, you can remove the check icon after transferring.
- Loading should be the patternfly style: https://www.patternfly.org/widgets/#spinner
- Select should be patternfly style: https://www.patternfly.org/widgets/#bootstrap-select
- The feedback message in the modal when transferring ownership should contain the line below: “This action can’t be undone.” See modal delete url for reference