### PR TITLE
Reduce the size of the angular generated DOM and increase runtime per…

### DIFF
--- a/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
@@ -24,6 +24,13 @@ module HawkularMetrics {
     'hawkular.services', 'ui.bootstrap', 'topbar', 'patternfly.select', 'angular-momentjs', 'angular-md5', 'toastr',
     'infinite-scroll', 'mgo-angular-wizard', 'truncate', '500tech.smart-truncate']);
 
+  _module.config(['$compileProvider', function ($compileProvider) {
+    //disable debug info
+    //NOTE: tools like Batarang and Protractor may not work properly with this debug info off
+    //However, this can be turned back on at runtime in the js console by typing: angular.reloadWithDebugInfo()
+    $compileProvider.debugInfoEnabled(false);
+  }]);
+
   _module.config(['$httpProvider', '$locationProvider', '$routeProvider',
     ($httpProvider, $locationProvider) => {
       $locationProvider.html5Mode(true);


### PR DESCRIPTION
…formance by turning off angular debug info.

Angular spits out all kinds of debug info that is not wanted in a production app. This info can easliy be turned back on at runtime by typing at the js console: angular.reloadWithDebugInfo().