### PR TITLE
Add partial sorting on AlertsCenter

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
@@ -59,16 +59,16 @@
           <thead>
           <tr>
             <th ng-click="ac.selectAll()"><input type="checkbox"/></th>
-            <th>State</th>
-            <th>Severity</th>
+            <th ng-class="{'sorting_asc': ac.sortField == 'status' && ac.sortAsc, 'sorting_desc': ac.sortField == 'status' && !ac.sortAsc, 'sorting': ac.sortField != 'status'}" ng-click="ac.sortBy('status')">State</th>
+            <th ng-class="{'sorting_asc': ac.sortField == 'severity' && ac.sortAsc, 'sorting_desc': ac.sortField == 'severity' && !ac.sortAsc, 'sorting': ac.sortField != 'severity'}" ng-click="ac.sortBy('severity')">Severity</th>
             <th>Description</th>
-            <th>Created</th>
+            <th ng-class="{'sorting_asc': ac.sortField == 'ctime' && ac.sortAsc, 'sorting_desc': ac.sortField == 'ctime' && !ac.sortAsc, 'sorting': ac.sortField != 'ctime'}" ng-click="ac.sortBy('ctime')" ng-click="ac.sortBy('ctime')">Created</th>
             <th>Resource Path</th>
             <th></th>
           </tr>
           </thead>
           <tbody>
-          <tr ng-repeat="alert in ac.alertsList | filter:ac.search" ng-class="{'hk-selected': ac.selected}"
+          <tr ng-repeat="alert in ac.alertsList | filter:ac.search | orderBy:ac.sortField:ac.sortAsc" ng-class="{'hk-selected': ac.selected}"
               ng-click="ac.selectItem(alert)">
             <td><input type="checkbox" ng-checked="alert.selected"/></td>
             <td ng-class="{'hk-bold': alert.status === 'OPEN'}">{{alert.status|firstUpper}}</td>

--- a/console/src/main/scripts/plugins/metrics/ts/alertsCenterList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alertsCenterList.ts
@@ -43,6 +43,8 @@ module HawkularMetrics {
     public hasOpenSelectedItems:boolean = false;
     public hasResolvedAlerts:boolean = false;
     public alertsStatuses:string = 'OPEN,ACKNOWLEDGED';
+    public sortField:string = 'ctime';
+    public sortAsc:boolean = false;
 
     public loadingMoreItems:boolean = false;
     public addProgress:boolean = false;
@@ -91,11 +93,18 @@ module HawkularMetrics {
       this.alertsTimeEnd = this.$routeParams.endTime ? this.$routeParams.endTime : Date.now();
       this.alertsTimeStart = this.alertsTimeEnd - this.alertsTimeOffset;
 
+      let ordering = 'asc';
+      if (!this.sortAsc) {
+        ordering = 'desc';
+      }
+
       this.HawkularAlertsManager.queryAlerts({statuses: this.alertsStatuses,
         startTime: this.alertsTimeStart,
         endTime: this.alertsTimeEnd,
         currentPage: this.alertsCurPage,
-        perPage: this.alertsPerPage
+        perPage: this.alertsPerPage,
+        sort: this.sortField,
+        order: ordering
         })
         .then((queriedAlerts) => {
           this.headerLinks = this.HkHeaderParser.parse(queriedAlerts.headers);
@@ -147,7 +156,7 @@ module HawkularMetrics {
       this.isWorking = true;
       let ackIdList = '';
       this.alertsList.forEach((alertItem:IAlert) => {
-        if (alertItem.selected && alertItem.status !== 'ACKNOWLEDGED' || alertItem.status !== 'RESOLVED') {
+        if (alertItem.selected && (alertItem.status !== 'ACKNOWLEDGED' || alertItem.status !== 'RESOLVED')) {
           ackIdList = ackIdList + alertItem.alertId + ',';
         }
       });
@@ -207,6 +216,13 @@ module HawkularMetrics {
         this.alertsStatuses = 'OPEN,ACKNOWLEDGED';
       }
       this.getAlerts();
+    }
+
+    public sortBy(field:string):void {
+      this.sortField = field;
+      this.sortAsc = !this.sortAsc;
+      this.getAlerts();
+      this.$log.debug('Sorting by ' + field + ' ascending ' + this.sortAsc + ' ' + new Date());
     }
 
   }


### PR DESCRIPTION
This PR implements sorting from server side.
There are pending tasks to be done, for example, it is needed to combine pagination + sorting.
This is not yet implemented but instead to send a full large commit I'm going to send small ones.
On this way, it is easy to cut for the MS having things on a stable way.
@mtho11 can you take a look, please ?
Thx.