### PR TITLE
HAWKULAR-557 Broken on Windows

### DIFF
--- a/dist/src/main/resources/wildfly/patches/standalone.xsl
+++ b/dist/src/main/resources/wildfly/patches/standalone.xsl
@@ -165,7 +165,7 @@
             defaultUser
           </config-property>
         ]]></xsl:comment>
-        <config-property name="ServerUrl">vm://org.hawkular.bus.broker.${jboss.node.name}?create=false&amp;jms.blobTransferPolicy.uploadUrl=file:${jboss.server.data.dir}/hawkular-bus-blobs</config-property>
+        <config-property name="ServerUrl">vm://org.hawkular.bus.broker.${jboss.node.name}?create=false&amp;jms.blobTransferPolicy.uploadUrl=file:${org.hawkular.data.dir:${jboss.server.data.dir}}/hawkular-bus-blobs</config-property>
         <connection-definitions>
           <connection-definition class-name="org.apache.activemq.ra.ActiveMQManagedConnectionFactory"
                                  jndi-name="java:/HawkularBusConnectionFactory"


### PR DESCRIPTION
The use of ${jboss.server.data.dir} in a URI inside of standalone.xml is
a problem. The windows path backslashes are not valid.  Instead, use the
new org.hawkular.data.dir, defaulting back to the jboss property.  This
allows windows users to set the new property on the command line to
bypass the issue (or to use a directory not under the jboss server,
if desired)