### PR TITLE
Move alerts actions into a dropdown

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
@@ -24,7 +24,6 @@
       </div>
     </div>
 
-    <!-- have alerts -->
     <div ng-show="ac.alertsList.length > 0">
 
       <div class="hk-info-top clearfix">
@@ -35,12 +34,16 @@
 
       <div class="hk-table-container">
         <div class="hk-actions-table">
-          <button class="btn btn-default" type="button" ng-click="ac.ackSelected()"
-                  ng-disabled="!ac.hasOpenSelectedItems || ac.isWorking">Acknowledge
-          </button>
-          <button class="btn btn-primary" type="button" ng-click="ac.resolveSelected()"
-                  ng-disabled="ac.selectCount < 1 || ac.isWorking || ac.hasResolvedItems()">Resolve
-          </button>
+          <div class="dropdown">
+            <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown">
+              Change State
+              <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
+              <li role="presentation"><a role="menuitem" tabindex="-1" href="#" ng-click="ac.ackSelected()" ng-disabled="!ac.hasOpenSelectedItems || ac.isWorking">Acknowledge</a></li>
+              <li role="presentation"><a role="menuitem" tabindex="-1" href="#" ng-click="ac.resolveSelected()" ng-disabled="ac.selectCount < 1 || ac.isWorking || ac.hasResolvedItems()">Resolve</a></li>
+            </ul>
+          </div>
         </div>
         <div class="dataTables_header">
           <div id="DataTables_Table_0_filter" class="dataTables_filter">
@@ -71,7 +74,7 @@
           <tr ng-repeat="alert in ac.alertsList | filter:ac.search" ng-class="{'hk-selected': ac.selected}"
               ng-click="ac.selectItem(alert)">
             <td><input type="checkbox" ng-checked="alert.selected"/></td>
-            <td ng-class="{'hk-bold': alert.status === 'OPEN'}">{{alert.status|firstUpper}}</td>
+            <td ng-class="{'hk-bold': alert.status === 'OPEN'}">{{alert.status|firstUpper}} <i ng-show="(alert.status === 'ACKNOWLEDGED' && alert.ackNotes.length > 0) || (alert.status === 'RESOLVED' && alert.resolvedNotes.length > 0)" class="fa fa-comment-o"></i></td>
             <td>{{alert.severity|firstUpper}}</td>
             <td>{{alert.trigger.description| characters: 35}}</td>
             <td>{{alert.ctime | date:'d MMM yyyy, HH:mm'}}</td>

--- a/console/src/main/scripts/plugins/metrics/ts/alertsCenterList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alertsCenterList.ts
@@ -136,17 +136,19 @@ module HawkularMetrics {
       });
       resolveIdList = resolveIdList.slice(0, -1);
 
-      let resolvedAlerts = {
-        alertIds: resolveIdList,
-        resolvedBy: this.$rootScope.currentPersona.name,
-        resolvedNotes: 'Manually resolved'
-      };
+      if (resolveIdList.length > 0) {
+        let resolvedAlerts = {
+          alertIds: resolveIdList,
+          resolvedBy: this.$rootScope.currentPersona.name,
+          resolvedNotes: ''
+        };
 
-      this.HawkularAlertsManager.resolveAlerts(resolvedAlerts).then(() => {
-        this.isWorking = false;
-        this.resetAllUnselected();
-        this.getAlerts();
-      });
+        this.HawkularAlertsManager.resolveAlerts(resolvedAlerts).then(() => {
+          this.isWorking = false;
+          this.resetAllUnselected();
+          this.getAlerts();
+        });
+      }
     }
 
 
@@ -161,18 +163,19 @@ module HawkularMetrics {
       });
       ackIdList = ackIdList.slice(0, -1);
 
-      let ackAlerts = {
-        alertIds: ackIdList,
-        ackBy: this.$rootScope.currentPersona.name,
-        ackNotes: 'Manually acknowledged'
-      };
+      if (ackIdList.length > 0) {
+        let ackAlerts = {
+          alertIds: ackIdList,
+          ackBy: this.$rootScope.currentPersona.name,
+          ackNotes: ''
+        };
 
-      this.HawkularAlertsManager.ackAlerts(ackAlerts).then(() => {
-        this.isWorking = false;
-        this.resetAllUnselected();
-        this.getAlerts();
-      });
-
+        this.HawkularAlertsManager.ackAlerts(ackAlerts).then(() => {
+          this.isWorking = false;
+          this.resetAllUnselected();
+          this.getAlerts();
+        });
+      }
     }
 
     public setPage(page:number):void {


### PR DESCRIPTION
Last minor to have updated the same style as presented by UI for "View Alerts" umbrella.
There are pending things not yet implemented as we need support from backend:
- Sorting by trigger context is not yet supported in Alerts.
- Comments are only supported on transition state but not as generic ones per alert, this need also support on the backend.

@mtho11 please, if you can take a look and merge, with this the AlertCenter has a good progress in this area.

I'm going to move into Hawkular Alerts to add these pendings services, back into UI when ready.