### PR TITLE
Add tabs for AlertsCenter

### DIFF
--- a/console/src/main/scripts/plugins/directives/subtab/html/subtab.html
+++ b/console/src/main/scripts/plugins/directives/subtab/html/subtab.html
@@ -4,7 +4,7 @@
       <div class="col-xs-6">
         <a ng-show="isAppServerPage()" href="/hawkular-ui/app/app-list" class="back">« All Application Servers</a>
         <a ng-hide="isUrlPage()" href="/hawkular-ui/url/url-list" class="back">« All URLs</a>
-        <a ng-show="isAlertsCenterPage()" href="/hawkular-ui/alerts-center" class="back">« All Alerts</a>
+        <a ng-show="isAlertsPage()" href="/hawkular-ui/alerts-center" class="back">« All Alerts</a>
       </div>
       <div class="col-xs-6">
         <div class="hk-date-range dropdown">
@@ -31,6 +31,7 @@
     </div>
     <div class="hk-heading">
       <h1 ng-init="isAppServerPage() ? getAppServerFromId(hkParams.resourceId) : getUrlFromId(hkParams.resourceId)">{{resourceName}}</h1>
+      <h1 ng-show="isAlertsPage()">Alert Center</h1>
     </div>
     <div ng-transclude></div>
   </div>

--- a/console/src/main/scripts/plugins/directives/subtab/ts/subtabDirective.ts
+++ b/console/src/main/scripts/plugins/directives/subtab/ts/subtabDirective.ts
@@ -33,7 +33,7 @@ module Subtab {
                                                                                HawkularNav, HawkularInventory) => {
 
       $scope.isAlertsPage = () => {
-        return $location.path().indexOf('/hawkular/ui/alerts-center') !== 0;
+        return $location.path().indexOf('/hawkular-ui/alerts-center') === 0;
       };
 
       $scope.isUrlPage = () => {

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
@@ -8,16 +8,12 @@
         </div>
       </div>
       <div class="hk-heading">
-        <h1>Alert Center</h1>
+        <h1>Alert Details</h1>
       </div>
     </div>
   </div>
 
   <div class="container">
-
-    <div class="hk-info-top clearfix">
-      <h3 class="pull-left">Alert Details</h3>
-    </div>
 
     <div class="row">
       <div class="col-md-9">

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
@@ -68,9 +68,9 @@
             <th ng-click="ac.selectAll()"><input type="checkbox"/></th>
             <th ng-class="{'sorting_asc': ac.sortField == 'status' && ac.sortAsc, 'sorting_desc': ac.sortField == 'status' && !ac.sortAsc, 'sorting': ac.sortField != 'status'}" ng-click="ac.sortBy('status')">State</th>
             <th ng-class="{'sorting_asc': ac.sortField == 'severity' && ac.sortAsc, 'sorting_desc': ac.sortField == 'severity' && !ac.sortAsc, 'sorting': ac.sortField != 'severity'}" ng-click="ac.sortBy('severity')">Severity</th>
-            <th>Description</th>
+            <th ng-class="{'sorting_asc': ac.sortField == 'context.description' && ac.sortAsc, 'sorting_desc': ac.sortField == 'context.description' && !ac.sortAsc, 'sorting': ac.sortField != 'context.description'}" ng-click="ac.sortBy('context.description')">Description</th>
             <th ng-class="{'sorting_asc': ac.sortField == 'ctime' && ac.sortAsc, 'sorting_desc': ac.sortField == 'ctime' && !ac.sortAsc, 'sorting': ac.sortField != 'ctime'}" ng-click="ac.sortBy('ctime')" ng-click="ac.sortBy('ctime')">Created</th>
-            <th>Resource Path</th>
+            <th ng-class="{'sorting_asc': ac.sortField == 'context.resourcePath' && ac.sortAsc, 'sorting_desc': ac.sortField == 'context.resourcePath' && !ac.sortAsc, 'sorting': ac.sortField != 'context.resourcePath'}" ng-click="ac.sortBy('context.resourcePath')">Resource Path</th>
             <th></th>
           </tr>
           </thead>

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
@@ -1,10 +1,14 @@
 <div class="hk-screen-content">
-
   <hawkular-subtab ng-controller="Subtab.SubtabController">
+    <div class="hk-nav-tabs-container">
+      <ul class="nav nav-tabs nav-tabs-pf">
+        <li class="active"><a href="/hawkular-ui/alerts-center" class="hk-alerts">All Alerts</a></li>
+        <li><a href="#" class="hk-availability">Definitions</a></li>
+      </ul>
+    </div>
   </hawkular-subtab>
 
   <div class="hk-alert-center">
-    <h1 class="text-center">Alert Center</h1>
 
     <!-- No Alerts -->
     <div ng-show="ac.alertsList.length === 0">

--- a/console/src/main/scripts/plugins/metrics/ts/alertsCenterList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alertsCenterList.ts
@@ -61,7 +61,7 @@ module HawkularMetrics {
                 private $location:ng.ILocationService) {
       $scope.ac = this;
 
-      this.alertsTimeOffset = $routeParams.timeOffset || 3600000;
+      this.alertsTimeOffset = $routeParams.timeOffset || 3600000 * 12;
       // If the end time is not specified in URL use current time as end time
       this.alertsTimeEnd = $routeParams.endTime ? $routeParams.endTime : Date.now();
       this.alertsTimeStart = this.alertsTimeEnd - this.alertsTimeOffset;

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmAlerts.ts
@@ -94,6 +94,7 @@ module HawkularMetrics {
             severity: 'MEDIUM',
             actions: {email: [this.defaultEmail]},
             context: {
+              description: 'JVM Heap Used for ' + resourceId, // Workaround for sorting
               resourceType: 'App Server',
               resourceName: resourceId,
               resourcePath: this.$rootScope.resourcePath
@@ -152,6 +153,7 @@ module HawkularMetrics {
             severity: 'HIGH',
             actions: {email: [this.defaultEmail]},
             context: {
+              description: 'JVM Non Heap Used for ' + resourceId, // Workaround for sorting
               resourceType: 'App Server',
               resourceName: resourceId,
               resourcePath: this.$rootScope.resourcePath
@@ -207,6 +209,7 @@ module HawkularMetrics {
             severity: 'HIGH',
             actions: {email: [this.defaultEmail]},
             context: {
+              description: 'Accumulated GC Duration for ' + resourceId, // Workaround for sorting
               resourceType: 'App Server',
               resourceName: resourceId,
               resourcePath: this.$rootScope.resourcePath

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebAlerts.ts
@@ -94,6 +94,7 @@ module HawkularMetrics {
             severity: 'MEDIUM',
             actions: {email: [this.defaultEmail]},
             context: {
+              description: 'Active Web Sessions for ' + resourceId, // Workaround for sorting
               resourceType: 'App Server',
               resourceName: resourceId,
               resourcePath: this.$rootScope.resourcePath
@@ -153,6 +154,7 @@ module HawkularMetrics {
               severity: 'LOW',
               actions: {email: [this.defaultEmail]},
               context: {
+                description: 'Expired Web Sessions for ' + resourceId, // Workaround for sorting
                 resourceType: 'App Server',
                 resourceName: resourceId,
                 resourcePath: this.$rootScope.resourcePath
@@ -210,6 +212,7 @@ module HawkularMetrics {
               severity: 'LOW',
               actions: {email: [this.defaultEmail]},
               context: {
+                description: 'Rejected Web Sessions for ' + resourceId, // Workaround for sorting
                 resourceType: 'App Server',
                 resourceName: resourceId,
                 resourcePath: this.$rootScope.resourcePath

--- a/console/src/main/scripts/plugins/metrics/ts/urlList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/urlList.ts
@@ -218,6 +218,7 @@ module HawkularMetrics {
               severity: 'HIGH',
               actions: {email: [defaultEmail]},
               context: {
+                description: 'Response Time for URL ' + url, // Workaround for sorting
                 resourceType: 'URL',
                 resourceName: url,
                 resourcePath: resourcePath
@@ -281,6 +282,7 @@ module HawkularMetrics {
               severity: 'CRITICAL',
               actions: {email: [defaultEmail]},
               context: {
+                description: 'Availability for URL ' + url, // Workaround for sorting
                 resourceType: 'URL',
                 resourceName: url,
                 resourcePath: resourcePath


### PR DESCRIPTION
Small PR to introduce tabs into AlertCenter.
@jshaughn can you review ? 
You can follow same pattern for the definitions, I used a simple way (similar as metrics) as we are only have two main sections, so no need to create a main controller for tabs, we can move between sections via router parameters (as it works for the datepicker filter).