### PR TITLE
Move calls to (bucketed) metrics all to MetricsService

### DIFF
--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesDetails.ts
@@ -368,46 +368,46 @@ module HawkularMetrics {
       angular.forEach(this.resourceList, function(res, idx) {
 
         if (!this.skipChartData[res.id + '_Available Count']) {
-          availPromises.push(this.HawkularMetric.GaugeMetricData(tenantId).queryMetrics({
-            gaugeId: 'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~Available Count',
-            start: this.startTimeStamp,
-            end: this.endTimeStamp, buckets: 60
-          }, (data) => {
+          let dsAvailPromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
+            'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~Available Count',
+            this.startTimeStamp, this.endTimeStamp, 60);
+          availPromises.push(dsAvailPromise);
+          dsAvailPromise.then((data) => {
             tmpChartAvailData[res.id] = tmpChartAvailData[res.id] || [];
             tmpChartAvailData[res.id][tmpChartAvailData[res.id].length] = {
               key: 'Available Count',
               color: AppServerDatasourcesDetailsController.AVAILABLE_COLOR,
               values: MetricsService.formatBucketedChartOutput(data)
             };
-          }, this).$promise);
+          });
         }
         if (!this.skipChartData[res.id + '_In Use Count']) {
-          availPromises.push(this.HawkularMetric.GaugeMetricData(tenantId).queryMetrics({
-            gaugeId: 'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~In Use Count',
-            start: this.startTimeStamp,
-            end: this.endTimeStamp, buckets: 60
-          }, (data) => {
+          let dsInUsePromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
+            'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~In Use Count',
+            this.startTimeStamp, this.endTimeStamp, 60);
+          availPromises.push(dsInUsePromise);
+          dsInUsePromise.then((data) => {
             tmpChartAvailData[res.id] = tmpChartAvailData[res.id] || [];
             tmpChartAvailData[res.id][tmpChartAvailData[res.id].length] = {
               key: 'In Use',
               color: AppServerDatasourcesDetailsController.IN_USE_COLOR,
               values: MetricsService.formatBucketedChartOutput(data)
             };
-          }, this).$promise);
+          });
         }
         if (!this.skipChartData[res.id + '_Timed Out']) {
-          availPromises.push(this.HawkularMetric.GaugeMetricData(tenantId).queryMetrics({
-            gaugeId: 'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~Timed Out',
-            start: this.startTimeStamp,
-            end: this.endTimeStamp, buckets: 60
-          }, (data) => {
+          let dsTimedPromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
+            'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~Timed Out',
+            this.startTimeStamp, this.endTimeStamp, 60);
+          availPromises.push(dsTimedPromise);
+          dsTimedPromise.then((data) => {
             tmpChartAvailData[res.id] = tmpChartAvailData[res.id] || [];
             tmpChartAvailData[res.id][tmpChartAvailData[res.id].length] = {
               key: 'Timed Out',
               color: AppServerDatasourcesDetailsController.TIMED_OUT_COLOR,
               values: MetricsService.formatBucketedChartOutput(data)
             };
-          }, this).$promise);
+          });
         }
         this.$q.all(availPromises).finally(()=> {
           this.chartAvailData[res.id] = tmpChartAvailData[res.id] || [];
@@ -415,32 +415,32 @@ module HawkularMetrics {
         });
 
         if (!this.skipChartData[res.id + '_Average Get Time']) {
-          respPromises.push(this.HawkularMetric.GaugeMetricData(tenantId).queryMetrics({
-            gaugeId: 'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~Average Get Time',
-            start: this.startTimeStamp,
-            end: this.endTimeStamp, buckets: 60
-          }, (data) => {
+          let dsWTimePromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
+            'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~Average Get Time',
+            this.startTimeStamp, this.endTimeStamp, 60);
+          respPromises.push(dsWTimePromise);
+          dsWTimePromise.then((data) => {
             tmpChartRespData[res.id] = tmpChartRespData[res.id] || [];
             tmpChartRespData[res.id][tmpChartRespData[res.id].length] = {
               key: 'Wait Time (Avg.)',
               color: AppServerDatasourcesDetailsController.WAIT_COLOR,
               values: MetricsService.formatBucketedChartOutput(data)
             };
-          }, this).$promise);
+          });
         }
         if (!this.skipChartData[res.id + '_Average Creation Time']) {
-          respPromises.push(this.HawkularMetric.GaugeMetricData(tenantId).queryMetrics({
-            gaugeId: 'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~Average Creation Time',
-            start: this.startTimeStamp,
-            end: this.endTimeStamp, buckets: 60
-          }, (data) => {
+          let dsCTimePromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
+            'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~Average Creation Time',
+            this.startTimeStamp, this.endTimeStamp, 60);
+          respPromises.push(dsCTimePromise);
+          dsCTimePromise.then((data) => {
             tmpChartRespData[res.id] = tmpChartRespData[res.id] || [];
             tmpChartRespData[res.id][tmpChartRespData[res.id].length] = {
               key: 'Creation Time (Avg.)',
               color: AppServerDatasourcesDetailsController.CREATION_COLOR,
               values: MetricsService.formatBucketedChartOutput(data)
             };
-          }, this).$promise);
+          });
         }
         this.$q.all(respPromises).finally(()=> {
           this.chartRespData[res.id] = tmpChartRespData[res.id] || [];

--- a/console/src/main/scripts/plugins/metrics/ts/metricsAvailability.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsAvailability.ts
@@ -37,7 +37,7 @@ module HawkularMetrics {
   export class MetricsAvailabilityController {
     /// for minification only
     public static  $inject = ['$scope', '$rootScope', '$interval', '$window', '$log', 'HawkularMetric',
-      '$routeParams', '$filter', '$moment', 'HawkularAlertsManager',
+      'MetricsService', '$routeParams', '$filter', '$moment', 'HawkularAlertsManager',
       'ErrorsManager', 'NotificationsService', '$modal'];
 
     private availabilityDataPoints:IChartDataPoint[] = [];
@@ -61,6 +61,7 @@ module HawkularMetrics {
                 private $window:any,
                 private $log:ng.ILogService,
                 private HawkularMetric:any,
+                private MetricsService:any,
                 private $routeParams:any,
                 private $filter:ng.IFilterService,
                 private $moment:any,
@@ -168,13 +169,9 @@ module HawkularMetrics {
                                           endTime:TimestampInMillis):void {
 
       if (metricId) {
-        this.HawkularMetric.AvailabilityMetricData(this.$rootScope.currentPersona.id).query({
-          availabilityId: metricId,
-          start: startTime,
-          end: endTime,
-          buckets: 1
-        }).$promise
-          .then((availResponse:IAvailabilitySummary[]) => {
+        this.MetricsService.retrieveAvailabilityMetrics(this.$rootScope.currentPersona.id,
+          metricId, startTime, endTime, 1).
+          then((availResponse:IAvailabilitySummary[]) => {
 
             if (availResponse && !_.last(availResponse).empty) {
 

--- a/console/src/main/scripts/plugins/metrics/ts/services/metricsService.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/metricsService.ts
@@ -62,9 +62,27 @@ module HawkularMetrics {
                         startTime?:TimestampInMillis,
                         endTime?:TimestampInMillis,
                         buckets?:number):ng.IPromise<IChartDataPoint[]>;
+    retrieveCounterMetrics(personaId:PersonaId, metricId:MetricId,
+                          startTime?:TimestampInMillis,
+                          endTime?:TimestampInMillis,
+                          buckets?:number):ng.IPromise<IChartDataPoint[]>;
+    retrieveCounterRateMetrics(personaId:PersonaId,
+                               metricId:MetricId,
+                               startTime?:TimestampInMillis,
+                               endTime?:TimestampInMillis,
+                               buckets?:number):ng.IPromise<IChartDataPoint[]>;
+    retrieveAvailabilityMetrics(personaId:PersonaId,
+                                metricId:MetricId,
+                                startTime?:TimestampInMillis,
+                                endTime?:TimestampInMillis,
+                                buckets?:number):ng.IPromise<IChartDataPoint[]>;
   }
 
   export class MetricsService implements IMetricsService {
+
+    private static AVAILABILITY_TYPE = 'Availability';
+    private static COUNTER_TYPE = 'Counter';
+    private static GAUGE_TYPE = 'Gauge';
 
     public static $inject = ['$log', 'HawkularMetric', 'NotificationsService'];
 
@@ -79,10 +97,8 @@ module HawkularMetrics {
      * @param response
      * @returns IChartDataPoint[]
      */
-    public static formatBucketedChartOutput(response,multiplier?: number):IChartDataPoint[] {
-      if (!multiplier) {
-          multiplier =1;
-      }
+    public static formatBucketedChartOutput(response, multiplier?: number):IChartDataPoint[] {
+      multiplier = multiplier || 1;
       //  The schema is different for bucketed output
       return _.map(response, (point:IChartDataPoint) => {
         return {
@@ -114,6 +130,71 @@ module HawkularMetrics {
                                endTime?:TimestampInMillis,
                                buckets = 120):ng.IPromise<IChartDataPoint[]> {
 
+      return this.retrieveMetrics(MetricsService.GAUGE_TYPE, personaId, metricId, startTime, endTime, buckets);
+    }
+
+    /**
+     * RetrieveCounterMetrics
+     * @param personaId
+     * @param metricId
+     * @param startTime
+     * @param endTime
+     * @param buckets
+     * @returns ng.IPromise<IChartDataPoint[]>
+     */
+    public retrieveCounterMetrics(personaId:PersonaId,
+                                  metricId:MetricId,
+                                  startTime?:TimestampInMillis,
+                                  endTime?:TimestampInMillis,
+                                  buckets = 120):ng.IPromise<IChartDataPoint[]> {
+
+      return this.retrieveMetrics(MetricsService.COUNTER_TYPE, personaId, metricId, startTime, endTime, buckets);
+    }
+
+    /**
+     * RetrieveCounterMetrics
+     * @param personaId
+     * @param metricId
+     * @param startTime
+     * @param endTime
+     * @param buckets
+     * @returns ng.IPromise<IChartDataPoint[]>
+     */
+    public retrieveCounterRateMetrics(personaId:PersonaId,
+                                      metricId:MetricId,
+                                      startTime?:TimestampInMillis,
+                                      endTime?:TimestampInMillis,
+                                      buckets = 120):ng.IPromise<IChartDataPoint[]> {
+
+      return this.retrieveMetrics(MetricsService.COUNTER_TYPE, personaId, metricId, startTime, endTime, buckets, true);
+    }
+
+    /**
+     * RetrieveCounterMetrics
+     * @param personaId
+     * @param metricId
+     * @param startTime
+     * @param endTime
+     * @param buckets
+     * @returns ng.IPromise<IChartDataPoint[]>
+     */
+    public retrieveAvailabilityMetrics(personaId:PersonaId,
+                                       metricId:MetricId,
+                                       startTime?:TimestampInMillis,
+                                       endTime?:TimestampInMillis,
+                                       buckets = 120):ng.IPromise<IChartDataPoint[]> {
+
+      return this.retrieveMetrics(MetricsService.AVAILABILITY_TYPE, personaId, metricId, startTime, endTime, buckets);
+    }
+
+    private retrieveMetrics(metricType:string,
+                            personaId:PersonaId,
+                            metricId:MetricId,
+                            startTime?:TimestampInMillis,
+                            endTime?:TimestampInMillis,
+                            buckets = 120,
+                            isRate?):ng.IPromise<IChartDataPoint[]> {
+
       // calling refreshChartData without params use the model values
       if (!endTime) {
         endTime = Date.now();
@@ -122,15 +203,18 @@ module HawkularMetrics {
         startTime = Date.now() - (8 * 60 * 60 * 1000);
       }
 
-      return this.HawkularMetric.GaugeMetricData(personaId).queryMetrics({
-        gaugeId: metricId,
+      let querySuffix = metricType === MetricsService.AVAILABILITY_TYPE ? '' : 'Metrics';
+      let dataType = isRate ? 'Rate' : 'Data';
+
+      return this.HawkularMetric[`${metricType}Metric${dataType}`](personaId)[`query${querySuffix}`]({
+        gaugeId: (metricType === MetricsService.GAUGE_TYPE ? metricId : undefined),
+        counterId: (metricType === MetricsService.COUNTER_TYPE ? metricId : undefined),
+        availabilityId: (metricType === MetricsService.AVAILABILITY_TYPE ? metricId : undefined),
         start: startTime,
         end: endTime,
         buckets: buckets
       }).$promise;
-
     }
-
 
   }
 


### PR DESCRIPTION
Non-bucketed calls are still not moved as it needs further changes. Also
moved all calls to formatBucketedChartOutput to use method from service.