### PR TITLE
Move charts back to 0.5.19 instead of snapshot

### DIFF
--- a/console/src/main/scripts/bower.json
+++ b/console/src/main/scripts/bower.json
@@ -23,7 +23,7 @@
     "animate.css": "3.0.0",
     "ngInfiniteScroll": "1.2.1",
     "bootstrap-select": "1.6",
-    "hawkular-charts": "hawkular/hawkular-charts#master",
+    "hawkular-charts": "0.5.19",
     "hawkular-ui-services": "hawkular/hawkular-ui-services#master",
     "hawtio-core-navigation": "2.0.51",
     "hawtio-core": "2.0.18",


### PR DESCRIPTION
This is because we are doing some breaking changes on master now.