### PR TITLE
HAWKULAR-500

### DIFF
--- a/console/src/main/scripts/plugins/topology/ts/d3Setup.ts
+++ b/console/src/main/scripts/plugins/topology/ts/d3Setup.ts
@@ -20,8 +20,7 @@
 
 module HawkularTopology {
 
-    _module.run(['$rootScope', '$location',
-      ($rootScope, $location) => {
+    _module.run(($rootScope, $location) => {
 
         /* A cache to prevent jumping when rapidly toggling views */
         var cache = {};
@@ -294,5 +293,5 @@ module HawkularTopology {
             };
         };
         HawkularTopology.initGraph = initGraph;
-    }]);
+    });
 }

--- a/console/src/main/scripts/plugins/topology/ts/topologyGlobals.ts
+++ b/console/src/main/scripts/plugins/topology/ts/topologyGlobals.ts
@@ -15,7 +15,7 @@
 /// limitations under the License.
 ///
 
-/// <reference path='../../includes.ts'/>	
+/// <reference path='../../includes.ts'/>
 
 module HawkularTopology {
 

--- a/console/src/main/scripts/plugins/topology/ts/topologyPlugin.ts
+++ b/console/src/main/scripts/plugins/topology/ts/topologyPlugin.ts
@@ -20,39 +20,27 @@
 
 module HawkularTopology {
 
-  _module.config([
-    '$routeProvider', 'HawtioNavBuilderProvider',
-    ($routeProvider, builder:HawtioMainNav.BuilderFactory) => {
+  _module.config(
+    ($routeProvider, HawtioNavBuilderProvider:HawtioMainNav.BuilderFactory) => {
 
       $routeProvider
       .when(
         '/hawkular-ui/topology/view',
-        { templateUrl: builder.join(HawkularTopology.templatePath, 'index.html') }
+        { templateUrl: HawtioNavBuilderProvider.join(HawkularTopology.templatePath, 'index.html') }
         );
-    }]);
+    });
 
   export class TopologyController {
-    public static $inject = ['$rootScope', '$scope', '$interval', '$log', '$routeParams', '$modal', '$q',
-    'HawkularAccount', 'HawkularInventory', /*'NotificationsApp',*/ 'userDetails'];
     private data: any;
     private index = 0;
-    private partialData: any;
     private kinds: any;
     private autoRefreshPromise: ng.IPromise<any>;
 
     constructor(private $rootScope:any,
       private $scope: any,
-      // private $log:ng.ILogApp,
       private $interval: ng.IIntervalService,
-      private $log:any,
-      private $routeParams:any,
-      private $modal:any,
-      // private $q: ng.IQApp,
       private $q: any,
-      private HawkularAccount:any,
-      private HawkularInventory:any,
-      // private NotificationsApp:INotificationsApp,
-      private userDetails:any) {
+      private HawkularInventory:any) {
 
 
       var datasets = [];


### PR DESCRIPTION
Injections are now handled with ng-annotate during gulp build, so they can be removed from .ts files. Be careful about variable names , as they should have same name as is registered in module. In this case HawtioNavBuilderProvider was named builder which was not recognized with ng-annotate and threw error.