### PR TITLE
ui-services tests fails because the http localhost 9876 triplet is no…

### DIFF
--- a/dist/src/main/resources/configuration/hawkular-realm-for-dev.json
+++ b/dist/src/main/resources/configuration/hawkular-realm-for-dev.json
@@ -88,7 +88,7 @@
       "bearerOnly" : false,
       "publicClient": false,
       "redirectUris": ["/*", "http://localhost:8080/*", "http://127.0.0.1:8080/*"],
-      "webOrigins": ["http://localhost:2772", "http://localhost:8080", "http://127.0.0.1:8080"],
+      "webOrigins": ["http://localhost:2772", "http://localhost:8080", "http://127.0.0.1:8080", "http://localhost:9876"],
       "secret" : "${uuid.hawkular.accounts.backend}"
     },
     {

--- a/dist/src/main/resources/configuration/hawkular-realm.json
+++ b/dist/src/main/resources/configuration/hawkular-realm.json
@@ -66,7 +66,7 @@
       "bearerOnly" : false,
       "publicClient": false,
       "redirectUris": ["/*", "http://localhost:8080/*", "http://127.0.0.1:8080/*"],
-      "webOrigins": ["http://localhost:2772", "http://localhost:8080", "http://127.0.0.1:8080"],
+      "webOrigins": ["http://localhost:2772", "http://localhost:8080", "http://127.0.0.1:8080", "http://localhost:9876"],
       "secret" : "${uuid.hawkular.accounts.backend}"
     },
     {


### PR DESCRIPTION
…t white-listed among the allowed origins (PhantomJS uses the 9876 port)