### PR TITLE
HAWKULAR-788 - Topology view keeps showing the waiting spinner when no resource.

### DIFF
--- a/console/src/main/scripts/plugins/directives/topbar/html/topbar.html
+++ b/console/src/main/scripts/plugins/directives/topbar/html/topbar.html
@@ -8,7 +8,7 @@
   <li ng-class="getClass('/hawkular-ui/app/')">
     <a href="/hawkular-ui/app/app-list">Application Servers</a>
   </li>
-  <li ng-class="getClass('/hawkular-ui/topology/')" ng-show="$root.isExperimental">
+  <li ng-class="getClass('/hawkular-ui/topology/')">
     <a href="/hawkular-ui/topology/view">Topology</a>
   </li>
 </ul>

--- a/console/src/main/scripts/plugins/topology/html/index.html
+++ b/console/src/main/scripts/plugins/topology/html/index.html
@@ -1,9 +1,16 @@
 <div class="hk-application-servers" data-ng-controller="HawkularTopology.TopologyController as vm">
 
-  <div class="text-center hk-urls-list hk-spinner-container hawkular-topology-spinner" ng-hide="vm.data.relations.length">
+  <div class="text-center hk-urls-list hk-spinner-container hawkular-topology-spinner"
+    ng-hide="vm.data.relations.length || !vm.requestPending">
     <div class="spinner spinner-lg"></div>
     <p class="hk-spinner-legend-below">Loading...</p>
   </div>
+
+  <div class="text-center hk-urls-list hk-spinner-container hawkular-topology-spinner"
+    ng-hide="vm.data.relations.length || vm.requestPending">
+    <p class="hk-spinner-legend-below">No Data</p>
+  </div>
+
   <div ng-class="{'hk-fade-in': vm.data.relations.length}">
 
     <hawkular-topology-graph items="vm.data.items" relations="vm.data.relations" kinds="vm.kinds">


### PR DESCRIPTION
Displaying the spinner only during the call of `getData()`. If the inventory is empty, "No Data" is displayed instead of the spinner.

Also making the topology graph visible by default.