### PR TITLE
Update to Command GW 0.10.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <version.org.hawkular.alerts>0.6.0.Final-SRC-revision-53dafd419c5165f6fe4620d8d09ec64a6d068cbf</version.org.hawkular.alerts>
     <version.org.hawkular.bus>0.7.2.Final-SRC-revision-51939085c81845b21841503921d48442dde6f32b</version.org.hawkular.bus>
     <version.org.hawkular.commons>0.2.3.Final-SRC-revision-dc2c2fc6cd725df4b120458590208fcc52dd6080</version.org.hawkular.commons>
-    <version.org.hawkular.cmdgw>0.10.2.Final-SRC-revision-70128f2962949da23ba3e71a985871c2f9f509b3</version.org.hawkular.cmdgw>
+    <version.org.hawkular.cmdgw>0.10.3.Final</version.org.hawkular.cmdgw>
     <version.org.hawkular.metrics>0.9.0.Final</version.org.hawkular.metrics>
     <version.org.hawkular.inventory>0.8.1.Final</version.org.hawkular.inventory>
     <version.org.keycloak>1.6.1.Final</version.org.keycloak>


### PR DESCRIPTION
Required to make WS Ops work with latest inventory.