### PR TITLE
Hawkular-571 Alert Query by Resource

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
@@ -67,7 +67,7 @@
             <th ng-click="ac.selectAll()"><input type="checkbox"/></th>
             <th ng-class="{'sorting_asc': ac.sortField == 'status' && ac.sortAsc, 'sorting_desc': ac.sortField == 'status' && !ac.sortAsc, 'sorting': ac.sortField != 'status'}" ng-click="ac.sortBy('status')">State</th>
             <th ng-class="{'sorting_asc': ac.sortField == 'severity' && ac.sortAsc, 'sorting_desc': ac.sortField == 'severity' && !ac.sortAsc, 'sorting': ac.sortField != 'severity'}" ng-click="ac.sortBy('severity')">Severity</th>
-            <th ng-class="{'sorting_asc': ac.sortField == 'context.description' && ac.sortAsc, 'sorting_desc': ac.sortField == 'context.description' && !ac.sortAsc, 'sorting': ac.sortField != 'context.description'}" ng-click="ac.sortBy('context.description')">Description</th>
+            <th ng-class="{'sorting_asc': ac.sortField == 'trigger.description' && ac.sortAsc, 'sorting_desc': ac.sortField == 'trigger.description' && !ac.sortAsc, 'sorting': ac.sortField != 'trigger.description'}" ng-click="ac.sortBy('trigger.description')">Description</th>
             <th ng-class="{'sorting_asc': ac.sortField == 'ctime' && ac.sortAsc, 'sorting_desc': ac.sortField == 'ctime' && !ac.sortAsc, 'sorting': ac.sortField != 'ctime'}" ng-click="ac.sortBy('ctime')" ng-click="ac.sortBy('ctime')">Created</th>
             <th ng-class="{'sorting_asc': ac.sortField == 'context.resourceName' && ac.sortAsc, 'sorting_desc': ac.sortField == 'context.resourceName' && !ac.sortAsc, 'sorting': ac.sortField != 'context.resourceName'}" ng-click="ac.sortBy('context.resourceName')">Resource Name</th>
             <th></th>

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-triggers.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-triggers.html
@@ -70,7 +70,7 @@
             <td>{{trigger.description}}</td>
             <td><a ng-href="{{act.getResourceRoute(trigger)}}">{{trigger.context.resourceName|truncate: 30}}</a></td>
             <td>{{trigger.severity|firstUpper}}</td>
-            <td>{{trigger.enabled ? "True" : "False"}}</td>
+            <td>{{trigger.enabled ? "Enabled" : "Disabled"}}</td>
             <td>{{trigger.actions.email.length}} <i class="fa fa-envelope"></i></td>
             <td><a ng-href="{{act.getDetailRoute(trigger)}}" class="btn btn-link"><i class="fa fa-chevron-circle-right fa-lg"
                                            tooltip="View Details" tooltip-trigger tooltip-placement="top">

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-jvm.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-jvm.html
@@ -10,7 +10,7 @@
       <div class="panel panel-default hk-summary">
         <div class="row">
           <div class="col-sm-3 hk-summary-item">
-            <span class="hk-data">{{vm.alertList.length}} <i class="fa fa-flag" ng-show="vm.alertList.length > 0"></i></span>
+            <ng-span class="hk-data">{{vm.alertList.length}} <i class="fa fa-flag" ng-show="vm.alertList.length > 0"></i></ng-span>
             <span class="hk-item">JVM Alerts</span>
           </div>
           <div class="col-sm-3 hk-summary-item">

--- a/console/src/main/scripts/plugins/metrics/html/partials/trigger-alerts-sidebar.html
+++ b/console/src/main/scripts/plugins/metrics/html/partials/trigger-alerts-sidebar.html
@@ -12,7 +12,7 @@
               <i class="fa fa-exclamation-triangle hk-warning"></i>
             </div>
             <div class="hk-info-container">
-              <div class="hk-info-heading">{{alert.trigger.description}}</div>
+              <div class="hk-info-heading">{{alert.trigger.description | characters: 50 }}</div>
               <p class="hk-info-info">{{alert.ctime | date:'d MMM yyyy, HH:mm'}}</p>
             </div>
             <div class="hk-icon-container">

--- a/console/src/main/scripts/plugins/metrics/html/url-response-time.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-response-time.html
@@ -70,9 +70,9 @@
         </button>
       </h3>
       <span class="hk-settings pull-left">
-        <a href="#" ng-controller="MetricsAlertController as mac" ng-click="mac.openResponseSetup()">
-          <i class="fa fa-cog"></i>Alert Settings
-        </a>
+          <a ng-href="/hawkular-ui/alerts-center-triggers/{{vm.resourceId}}">
+            <i class="fa fa-cog"></i>Alert Settings
+          </a>
       </span>
     </div>
     <div class="clearfix">

--- a/console/src/main/scripts/plugins/metrics/ts/metricsAppServerDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsAppServerDetails.ts
@@ -171,7 +171,7 @@ module HawkularMetrics {
               resourceId: resourceId
             },
             context: {
-              description: 'JVM Heap Used for ' + resourceId, // Workaround for sorting
+              alertType: 'PHEAP',
               resourceType: 'App Server',
               resourceName: resourceId,
               resourcePath: this.$rootScope.resourcePath,
@@ -248,7 +248,7 @@ module HawkularMetrics {
               resourceId: resourceId
             },
             context: {
-              description: 'JVM Non Heap Used for ' + resourceId, // Workaround for sorting
+              alertType: 'NHEAP',
               resourceType: 'App Server',
               resourceName: resourceId,
               resourcePath: this.$rootScope.resourcePath,
@@ -308,7 +308,7 @@ module HawkularMetrics {
 
         let fullTrigger = {
           trigger: {
-            name: 'Accumulated GC Duration',
+            name: 'JVM Accumulated GC Duration',
             id: triggerId,
             description: 'Accumulated GC Duration for ' + resourceId,
             autoDisable: true, // Disable trigger after firing, to not have repeated alerts of same issue
@@ -320,7 +320,7 @@ module HawkularMetrics {
               resourceId: resourceId
             },
             context: {
-              description: 'Accumulated GC Duration for ' + resourceId, // Workaround for sorting
+              alertType: 'GARBA',
               resourceType: 'App Server',
               resourceName: resourceId,
               resourcePath: this.$rootScope.resourcePath,
@@ -370,7 +370,7 @@ module HawkularMetrics {
 
           let fullTrigger = {
             trigger: {
-              name: 'Active Web Sessions',
+              name: 'Web Sessions Active',
               id: triggerId,
               description: 'Active Web Sessions for ' + resourceId,
               autoDisable: true, // Disable trigger after firing, to not have repeated alerts of same issue
@@ -382,7 +382,7 @@ module HawkularMetrics {
                 resourceId: resourceId
               },
               context: {
-                description: 'Active Web Sessions for ' + resourceId, // Workaround for sorting
+                alertType: 'ACTIVE_SESSIONS',
                 resourceType: 'App Server',
                 resourceName: resourceId,
                 resourcePath: this.$rootScope.resourcePath,
@@ -433,7 +433,7 @@ module HawkularMetrics {
 
           let fullTrigger = {
             trigger: {
-              name: 'Expired Web Sessions',
+              name: 'Web Sessions Expired',
               id: triggerId,
               description: 'Expired Web Sessions for ' + resourceId,
               autoDisable: true, // Disable trigger after firing, to not have repeated alerts of same issue
@@ -445,7 +445,7 @@ module HawkularMetrics {
                 resourceId: resourceId
               },
               context: {
-                description: 'Expired Web Sessions for ' + resourceId, // Workaround for sorting
+                alertType: 'EXPIRED_SESSIONS',
                 resourceType: 'App Server',
                 resourceName: resourceId,
                 resourcePath: this.$rootScope.resourcePath,
@@ -494,7 +494,7 @@ module HawkularMetrics {
 
           let fullTrigger = {
             trigger: {
-              name: 'Rejected Web Sessions',
+              name: 'Web Sessions Rejected',
               id: triggerId,
               description: 'Rejected Web Sessions for ' + resourceId,
               autoDisable: true, // Disable trigger after firing, to not have repeated alerts of same issue
@@ -506,7 +506,7 @@ module HawkularMetrics {
                 resourceId: resourceId
               },
               context: {
-                description: 'Rejected Web Sessions for ' + resourceId, // Workaround for sorting
+                alertType: 'REJECTED_SESSIONS',
                 resourceType: 'App Server',
                 resourceName: resourceId,
                 resourcePath: this.$rootScope.resourcePath,

--- a/console/src/main/scripts/plugins/metrics/ts/metricsTypes.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsTypes.ts
@@ -141,9 +141,10 @@ module HawkularMetrics {
 
   // Alerts
   export  interface IAlertContext {
+    alertType: string;
     resourceName: string;
-    resourceType: string;
     resourcePath: ResourcePath;
+    resourceType: string;
   }
 
   export interface IAlertAction {

--- a/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
@@ -343,8 +343,14 @@ module HawkularMetrics {
 
           if (serverAlert.evalSets) {
 
+            console.log( serverAlert.trigger.name + ': ' + serverAlert.evalSets );
+
             for (let j = 0; j < serverAlert.evalSets.length; j++) {
               let evalItem = serverAlert.evalSets[j][0];
+
+              if (serverAlert.trigger.name === 'JVM Heap Used') {
+                console.log('evalItem:' + evalItem.value);
+              }
 
               if (!consoleAlert.start && evalItem.dataTimestamp) {
                 consoleAlert.start = evalItem.dataTimestamp;
@@ -367,7 +373,7 @@ module HawkularMetrics {
                 }
               }
 
-              sum += evalItem.value;
+              sum += ( evalItem.value ? evalItem.value : evalItem.value1 );  // handle compare conditions
               count++;
             }
 

--- a/console/src/main/scripts/plugins/metrics/ts/urlList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/urlList.ts
@@ -56,7 +56,6 @@ module HawkularMetrics {
     private resourceList;
     private resPerPage = 5;
     public resCurPage = 0;
-    public alertList;
     public lastUpdateTimestamp:Date = new Date();
     public headerLinks:any = {};
 
@@ -217,13 +216,15 @@ module HawkularMetrics {
               id: triggerId,
               name: 'URL Response [' + url + ']',
               description: 'Response Time for URL ' + url,
+              autoEnable: true, // Enable trigger once an alert is resolved
+              autoResolve: true, // We do support AUTORESOLVE mode as an inverse of the firing conditions
               severity: 'HIGH',
               actions: {email: [defaultEmail]},
               tags: {
                 resourceId: resourceId
               },
               context: {
-                description: 'Response Time for URL ' + url, // Workaround for sorting
+                alertType: 'PINGRESPONSE',
                 resourceType: 'URL',
                 resourceName: url,
                 resourcePath: resourcePath,
@@ -285,13 +286,15 @@ module HawkularMetrics {
               id: triggerId,
               name: 'URL Down [' + url + ']',
               description: 'Availability for URL ' + url,
+              autoEnable: true, // Enable trigger once an alert is resolved
+              autoResolve: true, // We do support AUTORESOLVE mode as an inverse of the firing conditions
               severity: 'CRITICAL',
               actions: {email: [defaultEmail]},
               tags: {
                 resourceId: resourceId
               },
               context: {
-                description: 'Availability for URL ' + url, // Workaround for sorting
+                alertType: 'PINGAVAIL',
                 resourceType: 'URL',
                 resourceName: url,
                 resourcePath: resourcePath,
@@ -364,9 +367,6 @@ module HawkularMetrics {
           this.headerLinks = this.HkHeaderParser.parse(getResponseHeaders());
 
           aResourceList.expanded = this.resourceList ? this.resourceList.expanded : [];
-          this.HawkularAlertsManager.queryAlerts({statuses: 'OPEN'}).then((queriedAlerts) => {
-            this.alertList = queriedAlerts.alertList;
-          });
           let promises = [];
           angular.forEach(aResourceList, function (res) {
             let traitsArray:string[] = [];

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <version.gnu.getopt>1.0.13</version.gnu.getopt>
     <version.org.hawkular.accounts>1.1.1.Final-SRC-revision-3583f50aa1ae524dae320462a75ef9006b2d1fb3</version.org.hawkular.accounts>
     <version.org.hawkular.agent>0.12.0.Final</version.org.hawkular.agent>
-    <version.org.hawkular.alerts>0.6.0.Final-SRC-revision-53dafd419c5165f6fe4620d8d09ec64a6d068cbf</version.org.hawkular.alerts>
+    <version.org.hawkular.alerts>0.6.0.Final</version.org.hawkular.alerts>
     <version.org.hawkular.bus>0.7.2.Final</version.org.hawkular.bus>
     <version.org.hawkular.commons>0.2.3.Final-SRC-revision-dc2c2fc6cd725df4b120458590208fcc52dd6080</version.org.hawkular.commons>
     <version.org.hawkular.cmdgw>0.10.3.Final</version.org.hawkular.cmdgw>


### PR DESCRIPTION
- Replace using multiple triggerId queries with a single resourceId-tag query,
  when fetching alerts in the detail views.
  - We should avoid using IDs for any more than as a unique identifier.
  - We may now be able to make triggerIds UUIDs and not be comprised of
    resourceIds, which would be nicer when we use them in route urls.
  - store alertType on context for easy, consistent, non-hardcoded use.

Also:
- Bump root pom to Alerts 0.6.0.Final
- Do not use context.description for sorting the AC alerts list
  - Instead, use the new native trigger.description support offered by alerts
  - reason 1: context.descroption was not being set on all triggers
  - reason 2: trigger description is editable. The value presented on screen
    may not be the value used for sorting.
  - reason 3: context bloat
- Tweak JVM GC trigger name to start with 'JVM ' for better AC list grouping
- Fix Bug, fix Alert text for Heap alerts
- Fix bug, AC Definitions list State should be Enabled|Disabled, not True|False
- Fix Bug, Datasource triggers did not autodisable (or enable on resolve), make consistent with jvm triggers
- Fix Bug, URL triggers did not turn on autoresolve even though they had autoresolve support in the conditions, now uses autoresolve and also autoenable on resolve
- Fix bug, use ng-span as opposed to span element
- Fix bug, make sure description fits in alert sidebar box
- Fix bug, fix 'Alert Settings' link in URL Response Time tab view
- Fix bug, remove unused query for *all* open alerts
- Fix bug, make sure URL alerts query does not return prematurely