### PR TITLE
Hawkular 806

### DIFF
--- a/console/src/main/scripts/plugins/directives/topbar/html/topbar.html
+++ b/console/src/main/scripts/plugins/directives/topbar/html/topbar.html
@@ -11,4 +11,7 @@
   <li ng-class="getClass('/hawkular-ui/topology/')">
     <a href="/hawkular-ui/topology/view">Topology</a>
   </li>
+  <li ng-class="getClass('/hawkular-ui/agent-installer/')" ng-show="$root.isExperimental">
+    <a href="/hawkular-ui/agent-installer/view">Install Agent</a>
+  </li>
 </ul>

--- a/console/src/main/scripts/plugins/metrics/html/agent-installer.html
+++ b/console/src/main/scripts/plugins/metrics/html/agent-installer.html
@@ -1,0 +1,107 @@
+<div ng-controller="AgentInstallerController as aic" class="hk-agent-installer">
+  <div class="hk-heading">
+    <h1>Agent Installer</h1>
+  </div>
+
+  <div class="container">
+
+    <div class="col-lg-9 col-md-8">
+      <form class="panel panel-default clearfix">
+        <fieldset>
+          <div class="panel-heading">
+            <h2>Required</h2>
+          </div>
+          <div class="panel-body">
+            <div class="form-group">
+              <div class="row">
+                <label class="col-sm-3 control-label" for="hawkular-server-url">Hawkular Server URL</label>
+
+                <div class="col-sm-5">
+                  <div class="hk-input-text">
+                    <input class="form-control" type="url" ng-model="aic.hawkularServerUrl"
+                           placeholder="URL of Hawkular (e.g.: http://localhost:8080)" required hk-autofocus
+                           id="hawkular-server-url"/>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="form-group">
+              <div class="row">
+                <label class="col-sm-3 control-label" for="wildfly-home">Wildfly Home</label>
+
+                <div class="col-sm-5">
+                  <div class="input-group">
+                    <input ng-model="aic.wildflyHome"
+                           class="form-control" id="wildfly-home"/>
+
+                    <span class="btn btn-primary btn-file ">
+                      Browse <input type="file" webkitdirectory directory multiple/>
+                    </span>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+          </div>
+
+
+          <div class="panel-heading">
+            <h2>Optional</h2>
+          </div>
+          <div class="panel-body">
+
+            <div class="form-group">
+              <div class="row">
+                <label class="col-sm-3 control-label" for="module-zip">Module zip</label>
+
+                <div class="col-sm-5">
+                  <div class="input-group">
+                    <input ng-model="aic.moduleZip" class="form-control" id="module-zip"/>
+                      <span class="btn btn-primary btn-file ">
+                      Browse <input type="file"/>
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="form-group">
+              <div class="row">
+                <label class="col-sm-3 control-label" for="username">Username</label>
+
+                <div class="col-sm-5">
+                  <div class="hk-input-text">
+                    <input class="form-control" ng-model="aic.username" id="username"/>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <div class="row">
+                <label class="col-sm-3 control-label" for="password">Password</label>
+
+                <div class="col-sm-5">
+                  <div class="hk-input-text">
+                    <input class="form-control" type="password" ng-model="aic.password" id="password"/>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="form-aictions hk-form-aictions-separator text-right">
+              <button type="button" class="btn btn-primary" ng-click="aic.download()"
+                      ng-disabled="!aic.requiredFieldsFilled(hawkularServerUrl, wildflyHome)">
+                Download Installer
+              </button>
+            </div>
+          </div>
+
+        </fieldset>
+      </form>
+    </div>
+  </div>
+
+</div>

--- a/console/src/main/scripts/plugins/metrics/less/metrics.less
+++ b/console/src/main/scripts/plugins/metrics/less/metrics.less
@@ -2396,3 +2396,32 @@ section {
     padding-left: 15px;
   }
 }
+
+// Agent installer screen
+
+.hk-agent-installer {
+
+  .btn-file {
+    position: relative;
+    overflow: hidden;
+    width: 1%;
+    white-space: nowrap;
+    vertical-align: middle;
+    display: table-cell;
+  }
+  .btn-file input[type=file] {
+    position: absolute;
+    top: 0;
+    right: 0;
+    min-width: 100%;
+    min-height: 100%;
+    font-size: 100px;
+    text-align: right;
+    filter: alpha(opacity=0);
+    opacity: 0;
+    outline: none;
+    background: white;
+    cursor: inherit;
+    display: block;
+  }
+}

--- a/console/src/main/scripts/plugins/metrics/ts/agentInstaller.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/agentInstaller.ts
@@ -1,0 +1,69 @@
+///
+/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// and other contributors as indicated by the @author tags.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+/// <reference path='metricsPlugin.ts'/>
+/// <reference path='services/notificationsService.ts'/>
+
+module HawkularMetrics {
+
+  export class AgentInstallerController {
+
+    private httpUriPart = 'http://';
+    private hawkularServerUrl: string;
+    private wildflyHome: string;
+    private moduleZip: string;
+
+    private username: string;
+    private password: string;
+
+    constructor(private $location:ng.ILocationService,
+                private $scope:any,
+                private $rootScope:any,
+                private $log:ng.ILogService,
+                private $modal:any,
+                private NotificationsService:INotificationsService) {
+      $scope.aic = this;
+      this.hawkularServerUrl = this.httpUriPart;
+    }
+
+    public requiredFieldsFilled(hawkularServerUrl: string, wildflyHome: string): boolean {
+      return this.hawkularServerUrl !== undefined
+        && ((this.hawkularServerUrl.slice(0, 7) === 'http://' && this.hawkularServerUrl.length > 7)
+            || (this.hawkularServerUrl.slice(0, 8) === 'https://' && this.hawkularServerUrl.length > 8))
+        && this.wildflyHome !== undefined && this.wildflyHome.length > 2;
+    }
+
+    public download(): void {
+      var newPath = '/hawkular/wildfly-agent/download?installer=true&wildfly-home='
+        + encodeURIComponent(this.wildflyHome) + '&hawkular-server-url=' + encodeURIComponent(this.hawkularServerUrl);
+      if (this.moduleZip) {
+        newPath += '&module-zip=' + encodeURIComponent(this.moduleZip);
+      }
+      if (this.username) {
+        newPath += '&username=' + encodeURIComponent(this.username);
+      }
+      if (this.password) {
+        newPath += '&password=' + encodeURIComponent(this.password);
+      }
+      this.$log.info('downloading agent installer..');
+      window.location.href = newPath;
+    }
+
+  }
+  _module.controller('AgentInstallerController', AgentInstallerController);
+
+}

--- a/console/src/main/scripts/plugins/metrics/ts/globalController.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/globalController.ts
@@ -22,11 +22,10 @@ module HawkularMetrics {
 
   export class GlobalController {
 
-    public static  $inject = ['$scope', '$log', '$rootScope'];
-
     constructor(private $scope:any,
                 private $log:ng.ILogService,
-                private $rootScope:IHawkularRootScope
+                private $rootScope:IHawkularRootScope,
+                private NotificationsService:INotificationsService
     ) {
       $scope.global = this;
 
@@ -40,6 +39,7 @@ module HawkularMetrics {
       this.$rootScope.isExperimental = !this.$rootScope.isExperimental;
       if (this.$rootScope.isExperimental) {
         this.$log.info('Starting Experimental Mode');
+        this.NotificationsService.info('Entering Experimental Mode');
       } else {
         this.$log.info('Ending Experimental Mode');
       }

--- a/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
@@ -185,6 +185,7 @@ module HawkularMetrics {
         controller: 'ThresholdTriggerSetupController',
         controllerAs: 'tc'
       }).
+      when('/hawkular-ui/agent-installer/view', {templateUrl: 'plugins/metrics/html/agent-installer.html'}).
       otherwise({redirectTo: '/hawkular-ui/app/app-list'});
   }]);
 

--- a/dist/assembly.xml
+++ b/dist/assembly.xml
@@ -136,6 +136,19 @@
       <directoryMode>0755</directoryMode>
     </dependencySet>
 
+    <!-- put the agent installer to the same directory as previous artefact from the same reason -->
+    <dependencySet>
+      <outputDirectory>${hawkular.dist.zip.root.dir}/standalone/configuration</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+      <includes>
+        <include>org.hawkular.agent:hawkular-wildfly-agent-installer:jar</include>
+      </includes>
+      <outputFileNameMapping>agent-installer.${artifact.extension}</outputFileNameMapping>
+      <unpack>false</unpack>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+    </dependencySet>
+
     <!-- TODO Make the unpacking conditional == only for the dev profile -->
     <dependencySet>
       <outputDirectory>${hawkular.dist.zip.root.dir}/modules/org/hawkular/nest/main/deployments/${artifact.artifactId}.war</outputDirectory>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -62,6 +62,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hawkular.agent</groupId>
+      <artifactId>hawkular-wildfly-agent-installer</artifactId>
+      <version>${version.org.hawkular.agent}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.hawkular.inventory</groupId>
       <artifactId>hawkular-inventory-dist</artifactId>
       <type>war</type>

--- a/modules/hawkular-wildfly-agent-download/src/main/java/org/hawkular/component/wildflymonitor/WildFlyAgentServlet.java
+++ b/modules/hawkular-wildfly-agent-download/src/main/java/org/hawkular/component/wildflymonitor/WildFlyAgentServlet.java
@@ -58,6 +58,8 @@ public class WildFlyAgentServlet extends HttpServlet {
     private static String AGENT_INSTALLER_PROPERTY_WILDFLY_HOME = "wildfly-home";
     private static String AGENT_INSTALLER_PROPERTY_MODULE_DIST = "module-dist";
     private static String AGENT_INSTALLER_PROPERTY_HAWKULAR_SERVER = "hawkular-server-url";
+    private static String AGENT_INSTALLER_PROPERTY_USERNAME = "hawkular-username";
+    private static String AGENT_INSTALLER_PROPERTY_PASSWORD = "hawkular-password";
 
     // the error code that will be returned if the server has been configured to disable agent updates
     private static final int ERROR_CODE_AGENT_UPDATE_DISABLED = HttpServletResponse.SC_FORBIDDEN;
@@ -138,6 +140,8 @@ public class WildFlyAgentServlet extends HttpServlet {
                     "/hawkular/wildfly-agent/download" : "http://localhost:8080/wildfly-agent/download";
             final String moduleDist = getValueFromQueryParam(req, AGENT_INSTALLER_PROPERTY_MODULE_DIST,
                     defaultModuleDist);
+            final String username = getValueFromQueryParam(req, AGENT_INSTALLER_PROPERTY_USERNAME, null);
+            final String password = getValueFromQueryParam(req, AGENT_INSTALLER_PROPERTY_PASSWORD, null);
 
 
             for (Enumeration<? extends ZipEntry> e = agentInstallerZip.entries(); e.hasMoreElements(); ) {
@@ -170,6 +174,10 @@ public class WildFlyAgentServlet extends HttpServlet {
                             } else if (line.contains("#hawkular-server-url=http://localhost:8080")) {
                                 line = line.replaceAll("#hawkular-server-url=http://localhost:8080",
                                         "hawkular-server-url=" + hawkularServer);
+                            } else if (username != null && line.contains("hawkular-username=")) {
+                                line = line.replaceAll("hawkular-username=", "hawkular-username=" + username);
+                            } else if (password != null && line.contains("hawkular-password=")) {
+                                line = line.replaceAll("hawkular-password=", "hawkular-password=" + password);
                             }
                             byte[] buf = (line + '\n').getBytes(StandardCharsets.UTF_8);
                             zos.write(buf);


### PR DESCRIPTION
* extending the agent servlet to be able to serve the agent installer. The servlet takes couple of query params and puts their values into property file stored inside the jar so the user then can just download the jar and run 
```bash
java -jar agent-installer.jar
```
* Agent installer UI page with some form fields that are actually mapped into those properties from ^
(the page is by default hidden under the experimental mode)