### PR TITLE
HAWKULAR-752 Propagate timeOffset params across views

### DIFF
--- a/console/src/main/scripts/plugins/directives/subtab/html/subtab.html
+++ b/console/src/main/scripts/plugins/directives/subtab/html/subtab.html
@@ -2,12 +2,12 @@
   <div>
     <div class="row hk-top-row">
       <div class="col-xs-7">
-        <a ng-show="isAppServerPage()" href="/hawkular-ui/app/app-list" class="back">« All Application Servers</a>
-        <a ng-hide="isUrlPage()" href="/hawkular-ui/url/url-list" class="back">« All URLs</a>
-        <a ng-show="isAlertsCenterDetailPage()" href="/hawkular-ui/alerts-center-detail" class="back">« All Alerts</a>
+        <a ng-show="isAppServerPage()" href="/hawkular-ui/app/app-list/{{hkParams.timeOffset}}" class="back">« All Application Servers</a>
+        <a ng-hide="isUrlPage()" href="/hawkular-ui/url/url-list/{{hkParams.timeOffset}}" class="back">« All URLs</a>
+        <a ng-show="isAlertsCenterDetailPage()" href="/hawkular-ui/alerts-center-detail/{{hkParams.timeOffset}}" class="back">« All Alerts</a>
       </div>
       <div class="col-xs-5">
-        <div class="hk-date-range dropdown">
+        <div class="hk-date-range dropdown" ng-hide="isAlertsCenterTriggersPage()">
           <div class="input-group" dropdown-toggle>
             <div class="hk-input">
               {{offsetName}} <span ng-show="false">{{getFormattedDate()}}</span>

--- a/console/src/main/scripts/plugins/directives/subtab/ts/subtabDirective.ts
+++ b/console/src/main/scripts/plugins/directives/subtab/ts/subtabDirective.ts
@@ -40,6 +40,10 @@ module Subtab {
         return $location.path().indexOf('/hawkular-ui/alerts-center-detail') === 0;
       };
 
+      $scope.isAlertsCenterTriggersPage = () => {
+        return $location.path().indexOf('/hawkular-ui/alerts-center-triggers') === 0;
+      };
+
       $scope.isUrlPage = () => {
         return $location.path().indexOf('/hawkular-ui/url/') !== 0;
       };

--- a/console/src/main/scripts/plugins/directives/topbar/html/topbar.html
+++ b/console/src/main/scripts/plugins/directives/topbar/html/topbar.html
@@ -1,12 +1,12 @@
 <ul class="nav navbar-nav navbar-primary">
   <li ng-class="getClass('/hawkular-ui/alerts-center')">
-    <a href="/hawkular-ui/alerts-center">Alert Center</a>
+    <a href="/hawkular-ui/alerts-center/{{hkParams.timeOffset}}">Alert Center</a>
   </li>
   <li ng-class="getClass('/hawkular-ui/url/')">
-    <a href="/hawkular-ui/url/url-list">URLs</a>
+    <a href="/hawkular-ui/url/url-list/{{hkParams.timeOffset}}">URLs</a>
   </li>
   <li ng-class="getClass('/hawkular-ui/app/')">
-    <a href="/hawkular-ui/app/app-list">Application Servers</a>
+    <a href="/hawkular-ui/app/app-list/{{hkParams.timeOffset}}">Application Servers</a>
   </li>
   <li ng-class="getClass('/hawkular-ui/topology/')">
     <a href="/hawkular-ui/topology/view">Topology</a>

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
@@ -4,7 +4,7 @@
     <div class="container">
       <div class="row hk-top-row">
         <div class="col-xs-6">
-          <a href="/hawkular-ui/alerts-center" class="back">&laquo; All Alerts</a>
+          <a href="/hawkular-ui/alerts-center/{{hkParams.timeOffset}}" class="back">&laquo; All Alerts</a>
         </div>
       </div>
       <div class="hk-heading">

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
@@ -2,7 +2,7 @@
   <hawkular-subtab ng-controller="Subtab.SubtabController">
     <div class="hk-nav-tabs-container">
       <ul class="nav nav-tabs nav-tabs-pf">
-        <li class="active"><a href="/hawkular-ui/alerts-center" class="hk-alerts">Alerts</a></li>
+        <li class="active"><a href="/hawkular-ui/alerts-center/{{hkParams.timeOffset}}" class="hk-alerts">Alerts</a></li>
         <li><a href="/hawkular-ui/alerts-center-triggers" class="hk-availability">Definitions</a></li>
       </ul>
     </div>

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-triggers.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-triggers.html
@@ -2,7 +2,7 @@
   <hawkular-subtab ng-controller="Subtab.SubtabController">
     <div class="hk-nav-tabs-container">
       <ul class="nav nav-tabs nav-tabs-pf">
-        <li><a href="/hawkular-ui/alerts-center" class="hk-alerts">Alerts</a></li>
+        <li><a href="/hawkular-ui/alerts-center/{{hkParams.timeOffset}}" class="hk-alerts">Alerts</a></li>
         <li class="active"><a href="/hawkular-ui/alerts-center-triggers" class="hk-alerts">Definitions</a></li>
       </ul>
     </div>

--- a/console/src/main/scripts/plugins/metrics/html/app-server-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-server-list.html
@@ -127,10 +127,10 @@
             {{res.state | firstUpper}}
           </td>
           <td>
-            <a href="/hawkular-ui/app/app-details/{{res.id | limitTo : res.id.length-2}}/jvm">
+            <a href="/hawkular-ui/app/app-details/{{res.id | limitTo : res.id.length-2}}/jvm/{{hkParams.timeOffset}}">
               {{res.id | limitTo : res.id.length-2}}
             </a>
-            <a href="/hawkular-ui/app/app-details/{{res.id}}/jvm" class="pull-right">
+            <a href="/hawkular-ui/app/app-details/{{res.id}}/jvm/{{hkParams.timeOffset}}" class="pull-right">
               <span class="label label-danger label-alert" tooltip-trigger tooltip-placement="top"
                     tooltip="Server alerts" ng-show="res.alerts.length">{{res.alerts.length}}</span>
             </a>

--- a/console/src/main/scripts/plugins/metrics/html/directives/alert.html
+++ b/console/src/main/scripts/plugins/metrics/html/directives/alert.html
@@ -37,6 +37,9 @@
         <div ng-switch-when="DSRESP">
           <strong>Responsiveness</strong>: The connection {{alert.condition}} was {{alert.avg}} ms.
         </div>
+        <div ng-switch-when="DSCREATE">
+          <strong>Create Responsiveness</strong>: The connection {{alert.condition}} was {{alert.avg}} ms.
+        </div>
         <div ng-switch-when="ACTIVE_SESSIONS">
           <strong>Active Web Sessions</strong>: The number of active web sessions was {{alert.avg}}.
         </div>

--- a/console/src/main/scripts/plugins/metrics/html/url-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-list.html
@@ -47,34 +47,34 @@
     <!--<div class="hk-url-item" ng-repeat="res in vm.resourceList | orderBy:'properties.url':vm.reverse">-->
     <div class="hk-url-item" ng-repeat="res in vm.resourceList track by res.properties.url">
       <div class="panel panel-default hk-url-heading">
-        <a href="/hawkular-ui/url/availability/{{res.id}}">{{res.properties.url}}</a>
+        <a href="/hawkular-ui/url/availability/{{res.id}}/{{hkParams.timeOffset}}">{{res.properties.url}}</a>
         <span ng-show="res.properties['trait-collected-on']" class="pull-right">{{res.traits}}</span>
       </div>
 
       <div class="panel panel-default hk-summary">
         <div class="row">
           <div class="col-sm-3 hk-summary-item">
-            <a href="/hawkular-ui/url/alerts/{{res.id}}">
+            <a href="/hawkular-ui/url/alerts/{{res.id}}/{{hkParams.timeOffset}}">
               <span class="hk-data">{{(vm.alertList|filter:{triggerId: (res.id + '_trigger')}).length || 0}} <i class="fa fa-flag" ng-show="(vm.alertList|filter:{triggerId: (res.id + '_trigger')}).length > 0"></i></span>
               <span class="hk-item">Unresolved Alerts</span>
             </a>
           </div>
           <div class="col-sm-3 hk-summary-item">
-            <a href="/hawkular-ui/url/availability/{{res.id}}">
+            <a href="/hawkular-ui/url/availability/{{res.id}}/{{hkParams.timeOffset}}">
               <span class="hk-data" ng-show="res.responseTime.length > 0"><i class="fa " ng-class="res.isUp ? 'fa-arrow-up' : 'fa-arrow-down'"></i>{{res.isUp ? 'Up' : 'Down'}}</span>
               <span class="hk-data spinner" ng-hide="res.responseTime.length > 0" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
               <span class="hk-item">Current Availability</span>
             </a>
           </div>
           <div class="col-sm-3 hk-summary-item">
-            <a href="/hawkular-ui/url/availability/{{res.id}}">
+            <a href="/hawkular-ui/url/availability/{{res.id}}/{{hkParams.timeOffset}}">
               <span class="hk-data" ng-show="res.lastDowntime > 0" am-time-ago="res.lastDowntime" tooltip-trigger tooltip-placement="top" tooltip-popup-delay="1000" tooltip="{{ res.lastDowntime | date:'d MMM yyyy, HH:mm:ss' }}"></span>
               <span class="hk-data" ng-show="res.lastDowntime <= 0">n/a</span>
               <span class="hk-item">Last Downtime</span>
             </a>
           </div>
           <div class="col-sm-3 hk-summary-item">
-            <a href="/hawkular-ui/url/response-time/{{res.id}}">
+            <a href="/hawkular-ui/url/response-time/{{res.id}}/{{hkParams.timeOffset}}">
               <span class="hk-data" ng-show="res.responseTime.length > 0 && res.responseTime[0].value >= 0">{{res.responseTime[0].value}} <span>ms</span></span>
               <span class="hk-data" ng-show="res.responseTime.length > 0 && res.responseTime[0].value < 0">n/a</span>
               <span class="hk-data spinner" ng-hide="res.responseTime.length > 0" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>

--- a/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
@@ -59,7 +59,7 @@ module HawkularMetrics {
             return $q.defer().promise;
           }
         }
-      }).when('/hawkular-ui/url/url-list', {templateUrl: 'plugins/metrics/html/url-list.html'}).
+      }).when('/hawkular-ui/url/url-list/:timeOffset?/:endTime?', {templateUrl: 'plugins/metrics/html/url-list.html'}).
       when('/hawkular-ui/url/response-time/:resourceId/:timeOffset?/:endTime?', {
         templateUrl: 'plugins/metrics/html/url-response-time.html',
         reloadOnSearch: false,
@@ -117,7 +117,7 @@ module HawkularMetrics {
           }
         }
       }).
-      when('/hawkular-ui/app/app-list', {templateUrl: 'plugins/metrics/html/app-server-list.html'}).
+      when('/hawkular-ui/app/app-list/:timeOffset?/:endTime?', {templateUrl: 'plugins/metrics/html/app-server-list.html'}).
       when('/hawkular-ui/app/app-details/:resourceId/:tabId/:timeOffset?/:endTime?', {
         templateUrl: 'plugins/metrics/html/app-details/app-server-details.html',
         reloadOnSearch: false,

--- a/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
@@ -117,7 +117,8 @@ module HawkularMetrics {
           }
         }
       }).
-      when('/hawkular-ui/app/app-list/:timeOffset?/:endTime?', {templateUrl: 'plugins/metrics/html/app-server-list.html'}).
+      when('/hawkular-ui/app/app-list/:timeOffset?/:endTime?',
+      {templateUrl: 'plugins/metrics/html/app-server-list.html'}).
       when('/hawkular-ui/app/app-details/:resourceId/:tabId/:timeOffset?/:endTime?', {
         templateUrl: 'plugins/metrics/html/app-details/app-server-details.html',
         reloadOnSearch: false,


### PR DESCRIPTION
@mtho11, @ammendonca I've propagated the hkParams on urls where datepickers are used.
There is a pending question, if we should propagate hkParams across all views.
This PR only works on the case between alerts center, url, and app-server details, which I think is the most visible.
Please, let me know how it looks like, or feel free to take it as start point if you want to add some changes on top.