### PR TITLE
Hawkular-464 Deployment Failure Event Alerting

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-deployments.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-deployments.html
@@ -165,8 +165,8 @@
       </div>
     </div>
     <div class="col-lg-3">
-      <hk-alert-info list="vm.alertList" limit="(vm.showAllAlerts ? 100000 : 3)" resource-id="vm.resourceId"
-                     title="Deployments">
+      <hk-alert-info list="vm.alertList" limit="(vm.showAllAlerts ? 100000 : 3)"
+                     resource-id="vm.$routeParams.resourceId" title="Deployments">
       </hk-alert-info>
     </div>
   </div>

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-jvm.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-jvm.html
@@ -140,8 +140,8 @@
     </div>
 
     <div class="col-lg-3">
-      <hk-alert-info list="vm.alertList" limit="(vm.showAllAlerts ? 100000 : 3)" resource-id="vm.resourceId"
-                     title="JVM">
+      <hk-alert-info list="vm.alertList" limit="(vm.showAllAlerts ? 100000 : 3)"
+                     resource-id="vm.$routeParams.resourceId" title="JVM">
       </hk-alert-info>
     </div>
 

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-web.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-web.html
@@ -86,8 +86,8 @@
       </div>
     </div>
     <div class="col-lg-3">
-      <hk-alert-info list="vm.alertList" limit="(vm.showAllAlerts ? 100000 : 3)" resource-id="vm.resourceId"
-                     title="Web">
+      <hk-alert-info list="vm.alertList" limit="(vm.showAllAlerts ? 100000 : 3)"
+                     resource-id="vm.$routeParams.resourceId" title="Web">
       </hk-alert-info>
     </div>
   </div>

--- a/console/src/main/scripts/plugins/metrics/html/directives/alert.html
+++ b/console/src/main/scripts/plugins/metrics/html/directives/alert.html
@@ -49,6 +49,9 @@
         <div ng-switch-when="REJECTED_SESSIONS">
           <strong>Rejected Web Sessions</strong>: The number of rejected web sessions was {{alert.avg}}.
         </div>
+        <div ng-switch-when="DEPLOYMENT_FAIL">
+          <strong>Deployment Failed</strong>: {{alert.message}}.
+        </div>
         <div ng-switch-default>
           <strong>Alert</strong>: <code>{{alert}}</code>
         </div>

--- a/console/src/main/scripts/plugins/metrics/html/triggers/event.html
+++ b/console/src/main/scripts/plugins/metrics/html/triggers/event.html
@@ -29,14 +29,8 @@
 
               <fieldset>
                 {{tc.adm.trigger.conditionContext.description !== '' ?
-                  tc.adm.trigger.conditionContext.description : "Downtime"}}
+                  tc.adm.trigger.conditionContext.description : "Event"}}
               </fieldset>
-
-              <hk-fieldset-dampening hk-duration="tc.adm.trigger.evalTimeSetting"
-                                     hk-title="Downtime"
-                                     hk-title-met="Every time it goes down."
-                                     hk-title-unmet="Only when it is down for more than:">
-              </hk-fieldset-dampening>
 
               <hk-fieldset-notification hk-alert-email="tc.adm.trigger.email"></hk-fieldset-notification>
             </form>

--- a/console/src/main/scripts/plugins/metrics/html/url-alerts.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-alerts.html
@@ -2,9 +2,13 @@
   <hawkular-subtab ng-controller="Subtab.SubtabController">
     <div class="hk-nav-tabs-container">
       <ul class="nav nav-tabs nav-tabs-pf">
-        <li class="active"><a href="/hawkular-ui/url/alerts/{{mac.$routeParams.resourceId}}/{{mac.$routeParams.timeOffset}}" class="hk-alerts">All Alerts</a></li>
-        <li><a href="/hawkular-ui/url/availability/{{mac.$routeParams.resourceId}}/{{mac.$routeParams.timeOffset}}" class="hk-availability">Availability</a></li>
-        <li><a href="/hawkular-ui/url/response-time/{{mac.$routeParams.resourceId}}/{{mac.$routeParams.timeOffset}}" class="hk-response-time">Response Time</a></li>
+        <li class="active"><a
+          href="/hawkular-ui/url/alerts/{{mac.$routeParams.resourceId}}/{{mac.$routeParams.timeOffset}}"
+          class="hk-alerts">All Alerts</a></li>
+        <li><a href="/hawkular-ui/url/availability/{{mac.$routeParams.resourceId}}/{{mac.$routeParams.timeOffset}}"
+               class="hk-availability">Availability</a></li>
+        <li><a href="/hawkular-ui/url/response-time/{{mac.$routeParams.resourceId}}/{{mac.$routeParams.timeOffset}}"
+               class="hk-response-time">Response Time</a></li>
       </ul>
     </div>
   </hawkular-subtab>
@@ -13,9 +17,9 @@
     <div class="hk-info-top clearfix">
       <h3 class="pull-left">Alerts <span>({{(mac.alertList).length}})</span></h3>
       <span class="hk-settings pull-left">
-        <a href="#" ng-click="mac.openResponseSetup()"><i class="fa fa-cog"></i>Response Time Alert Settings</a>
-        <a href="#" ng-controller="MetricsAvailabilityController as vm" ng-click="vm.openAvailabilitySetup()">
-          <i class="fa fa-cog"></i>Availability Alert Settings</a>
+        <a ng-href="/hawkular-ui/alerts-center-triggers/{{mac.$routeParams.resourceId}}">
+          <i class="fa fa-cog"></i>Definitions
+        </a>
       </span>
     </div>
     <div ng-include="'plugins/metrics/html/partials/url-alerts-view.html'"></div>

--- a/console/src/main/scripts/plugins/metrics/html/url-availability.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-availability.html
@@ -80,15 +80,15 @@
         <button class="btn btn-link hk-trigger" ng-click="showAllAlerts = !showAllAlerts">
           <i ng-show="vm.alertList.length" ng-class="showAllAlerts ? 'fa fa-minus-square-o':'fa fa-plus-square-o'"></i>
           Availability Alerts
-          <span ng-show="vm.alertList.length">
-            ({{showAllAlerts ? vm.alertList.length : MetricsAvailabilityController.min(vm.alertList.length, 3)}} of
+          <ng-span ng-show="vm.alertList.length">
+            ({{showAllAlerts ? vm.alertList.length : vm.min(vm.alertList.length, 3)}} of
             {{vm.alertList.length}})
-          </span>
+          </ng-span>
         </button>
       </h3>
       <span class="hk-settings pull-left">
-          <a ng-href="/hawkular-ui/alerts-center-triggers/{{vm.resourceId}}">
-            <i class="fa fa-cog"></i>Alert Settings
+          <a ng-href="/hawkular-ui/alerts-center-triggers/{{vm.$routeParams.resourceId}}">
+            <i class="fa fa-cog"></i>Definitions
           </a>
       </span>
     </div>
@@ -109,7 +109,7 @@
       <h3 class="pull-left">Metrics</h3>
 
       <div class="hk-update pull-right">
-        <button ng-click="vm.refreshAvailPageNow(vm.getResourceId())" class="btn btn-link hk-chart-update"
+        <button ng-click="vm.refreshAvailPageNow(vm.$routeParams.resourceId)" class="btn btn-link hk-chart-update"
                 tooltip-trigger tooltip-placement="top" tooltip-append-to-body="true" tooltip="Update chart">
           <i class="fa fa-refresh"></i>
         </button>

--- a/console/src/main/scripts/plugins/metrics/html/url-response-time.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-response-time.html
@@ -63,15 +63,15 @@
         <button class="btn btn-link hk-trigger" ng-click="showAllAlerts = !showAllAlerts">
           <i ng-show="vm.alertList.length" ng-class="showAllAlerts? 'fa fa-minus-square-o' : 'fa fa-plus-square-o'"></i>
           Response Time Alerts
-          <span ng-show="vm.alertList.length">
-            ({{showAllAlerts ? vm.alertList.length : MetricsViewController.min(vm.alertList.length, 3)}} of
+          <ng-span ng-show="vm.alertList.length">
+            ({{showAllAlerts ? vm.alertList.length : vm.min(vm.alertList.length, 3)}} of
             {{vm.alertList.length}})
-          </span>
+          </ng-span>
         </button>
       </h3>
       <span class="hk-settings pull-left">
-          <a ng-href="/hawkular-ui/alerts-center-triggers/{{vm.resourceId}}">
-            <i class="fa fa-cog"></i>Alert Settings
+          <a ng-href="/hawkular-ui/alerts-center-triggers/{{vm.$routeParams.resourceId}}">
+            <i class="fa fa-cog"></i>Definitions
           </a>
       </span>
     </div>

--- a/console/src/main/scripts/plugins/metrics/ts/alertsCenterTriggerList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alertsCenterTriggerList.ts
@@ -188,17 +188,24 @@ module HawkularMetrics {
       let route = 'unknown-trigger-type';
       let encodedId = this.encodeResourceId(trigger.id);
 
-      if ('Availability' === trigger.context.triggerType) {
-        route = '/hawkular-ui/alerts-center-triggers/availability/' + encodedId;
-      } else if ('Event' === trigger.context.triggerType) {
-        route = '/hawkular-ui/alerts-center-triggers/event/' + encodedId;
-      } else if ('Range' === trigger.context.triggerType) {
-        route = '/hawkular-ui/alerts-center-triggers/range/' + encodedId;
-      } else if ('RangeByPercent' === trigger.context.triggerType) {
-        route = '/hawkular-ui/alerts-center-triggers/range-percent/' + encodedId;
-      } else if ('Threshold' === trigger.context.triggerType) {
-        route = '/hawkular-ui/alerts-center-triggers/threshold/' + encodedId;
+      switch (trigger.context.triggerType) {
+        case 'Availability' :
+          route = '/hawkular-ui/alerts-center-triggers/availability/' + encodedId;
+          break;
+        case 'Event' :
+          route = '/hawkular-ui/alerts-center-triggers/event/' + encodedId;
+          break;
+        case 'Range' :
+          route = '/hawkular-ui/alerts-center-triggers/range/' + encodedId;
+          break;
+        case 'RangeByPercent' :
+          route = '/hawkular-ui/alerts-center-triggers/range-percent/' + encodedId;
+          break;
+        case 'Threshold' :
+          route = '/hawkular-ui/alerts-center-triggers/threshold/' + encodedId;
+          break;
       }
+
       return route;
     }
 
@@ -206,23 +213,30 @@ module HawkularMetrics {
       let route = 'unknown-resource-type';
       let encodedId = this.encodeResourceId(trigger.id);
 
-      if ('App Server' === trigger.context.resourceType) {
-        route = '/hawkular-ui/app/app-details/' + trigger.context.resourceName + '/jvm';
-      } else if ('App Server Deployment' === trigger.context.resourceType) {
-        route = '/hawkular-ui/app/app-details/' + trigger.context.resourceName + '/deployments';
-      } else if ('DataSource' === trigger.context.resourceType) {
-        let resIdPart = trigger.context.resourceName.split('~/')[0];
-        route = '/hawkular-ui/app/app-details/' + resIdPart + '/datasources';
-      } else if ('URL' === trigger.context.resourceType) {
-        let parts = trigger.id.split('_trigger_');
-        let resourceId = parts[0];
-        let segment = ( parts[1] === 'thres' ) ? 'response-time' : 'availability';
-        route = '/hawkular-ui/url/' + segment + '/' + trigger.id.split('_trigger_')[0];
+      switch (trigger.context.resourceType) {
+        case 'App Server' :
+          route = '/hawkular-ui/app/app-details/' + trigger.context.resourceName + '/jvm';
+          break;
+        case 'App Server Deployment' :
+          route = '/hawkular-ui/app/app-details/' + trigger.context.resourceName + '/deployments';
+          break;
+        case 'DataSource' :
+          let resIdPart = trigger.context.resourceName.split('~/')[0];
+          route = '/hawkular-ui/app/app-details/' + resIdPart + '/datasources';
+          break;
+        case 'URL' :
+          let parts = trigger.id.split('_trigger_');
+          let resourceId = parts[0];
+          let segment = ( parts[1] === 'thres' ) ? 'response-time' : 'availability';
+          route = '/hawkular-ui/url/' + segment + '/' + trigger.id.split('_trigger_')[0];
+          break;
       }
+
       return route;
     }
 
-    public setPage(page:number):void {
+    public
+    setPage(page:number):void {
       this.triggersCurPage = page;
       this.getTriggers();
     }

--- a/console/src/main/scripts/plugins/metrics/ts/alertsCenterTriggerList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alertsCenterTriggerList.ts
@@ -190,6 +190,8 @@ module HawkularMetrics {
 
       if ('Availability' === trigger.context.triggerType) {
         route = '/hawkular-ui/alerts-center-triggers/availability/' + encodedId;
+      } else if ('Event' === trigger.context.triggerType) {
+        route = '/hawkular-ui/alerts-center-triggers/event/' + encodedId;
       } else if ('Range' === trigger.context.triggerType) {
         route = '/hawkular-ui/alerts-center-triggers/range/' + encodedId;
       } else if ('RangeByPercent' === trigger.context.triggerType) {
@@ -206,6 +208,8 @@ module HawkularMetrics {
 
       if ('App Server' === trigger.context.resourceType) {
         route = '/hawkular-ui/app/app-details/' + trigger.context.resourceName + '/jvm';
+      } else if ('App Server Deployment' === trigger.context.resourceType) {
+        route = '/hawkular-ui/app/app-details/' + trigger.context.resourceName + '/deployments';
       } else if ('DataSource' === trigger.context.resourceType) {
         let resIdPart = trigger.context.resourceName.split('~/')[0];
         route = '/hawkular-ui/app/app-details/' + resIdPart + '/datasources';

--- a/console/src/main/scripts/plugins/metrics/ts/alertsCenterTriggerList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alertsCenterTriggerList.ts
@@ -41,7 +41,7 @@ module HawkularMetrics {
     public hasDisabledSelectedItems:boolean = false;
     public sortField:string = 'name';
     public sortAsc:boolean = true;
-    public resourceId;
+
 
     public loadingMoreItems:boolean = false;
     public addProgress:boolean = false;
@@ -63,8 +63,6 @@ module HawkularMetrics {
       this.$rootScope.prevLocation = $location.url();
 
       this.autoRefresh(120);
-      this.resourceId = $routeParams.resourceId ?
-        this.decodeResourceId($routeParams.resourceId) : '';
 
       if ($rootScope.currentPersona) {
         this.getTriggers();
@@ -93,7 +91,8 @@ module HawkularMetrics {
         ordering = 'desc';
       }
 
-      let tagValue = this.resourceId ? this.resourceId : '*';
+      let resourceId:string = this.$routeParams.resourceId ?  this.decodeResourceId(this.$routeParams.resourceId) : '';
+      let tagValue = resourceId ?resourceId : '*';
       this.HawkularAlertsManager.queryTriggers({
         tags: 'resourceId|' + tagValue,
         currentPage: this.triggersCurPage,

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesDetails.ts
@@ -189,19 +189,19 @@ module HawkularMetrics {
         }, (aResourceList, getResponseHeaders) => {
           let promises = [];
           let tmpResourceList = [];
-          angular.forEach(aResourceList, (res:any) => {
+          angular.forEach(aResourceList, (res:IResource) => {
             if (res.id.startsWith(new RegExp(this.$routeParams.resourceId + '~/'))) {
               tmpResourceList.push(res);
               promises.push(this.HawkularMetric.GaugeMetricData(tenantId).queryMetrics({
                 gaugeId: 'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~Available Count',
                 distinct: true
-              }, (data) => {
+              }, (data:number[]) => {
                 res.availableCount = data[0];
               }).$promise);
               promises.push(this.HawkularMetric.GaugeMetricData(tenantId).queryMetrics({
                 gaugeId: 'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~In Use Count',
                 distinct: true
-              }, (data) => {
+              }, (data:number[]) => {
                 res.inUseCount = data[0];
               }).$promise);
               this.getAlerts(res);
@@ -224,16 +224,16 @@ module HawkularMetrics {
       this.getDrivers();
     }
 
-    private getAlerts(res:any):void {
+    private getAlerts(res:IResource):void {
       let dsArray:IAlert[];
       let promise = this.HawkularAlertsManager.queryAlerts({
         statuses: 'OPEN',
         tags: 'resourceId|' + res.id,
         startTime: this.startTimeStamp,
         endTime: this.endTimeStamp
-      }).then((data)=> {
-        _.forEach(data.alertList, (item) => {
-          item['alertType'] = item.context.alertType;
+      }).then((data:IHawkularAlertQueryResult)=> {
+        _.forEach(data.alertList, (item:IAlert) => {
+          item.alertType = item.context.alertType;
         });
         dsArray = data.alertList;
       }, (error) => {
@@ -270,7 +270,7 @@ module HawkularMetrics {
       let tmpChartAvailData = {};
       let tmpChartRespData = {};
 
-      _.forEach(this.resourceList, function (res:any) {
+      _.forEach(this.resourceList, function (res:IResource) {
 
         if (!this.skipChartData[res.id + '_Available Count']) {
           let dsAvailPromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
@@ -291,7 +291,7 @@ module HawkularMetrics {
             'MI~R~[' + res.id + ']~MT~Datasource Pool Metrics~In Use Count',
             this.startTimeStamp, this.endTimeStamp, 60);
           availPromises.push(dsInUsePromise);
-          dsInUsePromise.then((data) => {
+          dsInUsePromise.then((data:number[]) => {
             tmpChartAvailData[res.id] = tmpChartAvailData[res.id] || [];
             tmpChartAvailData[res.id][tmpChartAvailData[res.id].length] = {
               key: 'In Use',
@@ -362,7 +362,7 @@ module HawkularMetrics {
     public loadTriggers(currentTenantId?:TenantId):any {
       let tenantId:TenantId = currentTenantId || this.$rootScope.currentPersona.id;
 
-      _.forEach(this.resourceList, function (res:any, idx) {
+      _.forEach(this.resourceList, function (res:IResource, idx) {
 
         this.loadDatasourceTriggers(res.id);
 

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
@@ -31,7 +31,6 @@ module HawkularMetrics {
     private autoRefreshPromise:ng.IPromise<number>;
     private resourceList;
     public modalInstance;
-    public resourceId;
     public alertList;
     public selectCount:number = 0;
     public lastUpdateTimestamp:Date;
@@ -58,7 +57,6 @@ module HawkularMetrics {
       $scope.vm = this;
       HawkularOps.init(this.NotificationsService);
 
-      this.resourceId = this.$routeParams.resourceId;
       this.startTimeStamp = +moment().subtract(($routeParams.timeOffset || 3600000), 'milliseconds');
       this.endTimeStamp = +moment();
 
@@ -119,7 +117,7 @@ module HawkularMetrics {
       let alertArray: IAlert[];
       let promise = this.HawkularAlertsManager.queryAlerts({
         statuses: 'OPEN',
-        tags: 'resourceId|' + this.resourceId,
+        tags: 'resourceId|' + this.$routeParams.resourceId,
         startTime: this.startTimeStamp,
         endTime: this.endTimeStamp
       }).then((data:IHawkularAlertQueryResult)=> {
@@ -143,7 +141,8 @@ module HawkularMetrics {
 
     public getResourceList(currentTenantId?:TenantId):void {
       let tenantId:TenantId = currentTenantId || this.$rootScope.currentPersona.id;
-      let idParts = this.resourceId.split('~');
+      let resourceId:string = this.$routeParams.resourceId;
+      let idParts = resourceId.split('~');
       let feedId = idParts[0];
       this.HawkularInventory.ResourceOfTypeUnderFeed.query({
           environmentId: globalEnvironmentId,
@@ -153,7 +152,7 @@ module HawkularMetrics {
           let promises = [];
           let tmpResourceList = [];
           _.forEach(aResourceList, (res:IResource) => {
-            if (res.id.startsWith(new RegExp(this.resourceId + '~/'))) {
+            if (res.id.startsWith(new RegExp(resourceId + '~/'))) {
               tmpResourceList.push(res);
               res.selected = _.result(_.find(this.resourceList, {'id': res.id}), 'selected');
               promises.push(this.HawkularMetric.AvailabilityMetricData(this.$rootScope.currentPersona.id).query({

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
@@ -31,6 +31,7 @@ module HawkularMetrics {
     private autoRefreshPromise:ng.IPromise<number>;
     private resourceList;
     public modalInstance;
+    public resourceId;
     public alertList;
     public selectCount:number = 0;
     public lastUpdateTimestamp:Date;
@@ -57,7 +58,8 @@ module HawkularMetrics {
       $scope.vm = this;
       HawkularOps.init(this.NotificationsService);
 
-      this.startTimeStamp = +moment().subtract(1, 'hours');
+      this.resourceId = this.$routeParams.resourceId;
+      this.startTimeStamp = +moment().subtract(($routeParams.timeOffset || 3600000), 'milliseconds');
       this.endTimeStamp = +moment();
 
       if ($rootScope.currentPersona) {
@@ -68,18 +70,28 @@ module HawkularMetrics {
         this.getResourceList(currentPersona.id));
       }
 
+      this.getAlerts();
+
       this.autoRefresh(20);
     }
 
 
     private autoRefresh(intervalInSeconds:number):void {
       this.autoRefreshPromise = this.$interval(() => {
-        this.getResourceList();
+        this.refresh();
       }, intervalInSeconds * 1000);
 
       this.$scope.$on('$destroy', () => {
         this.$interval.cancel(this.autoRefreshPromise);
       });
+    }
+
+    public refresh():void {
+      this.endTimeStamp = this.$routeParams.endTime || +moment();
+      this.startTimeStamp = this.endTimeStamp - (this.$routeParams.timeOffset || 3600000);
+
+      this.getResourceList();
+      this.getAlerts();
     }
 
     public showDeploymentAddDialog():void {
@@ -103,14 +115,35 @@ module HawkularMetrics {
       });
     }
 
-    public refresh(): void {
-      this.getResourceList();
+    private getAlerts():void {
+      let alertArray: IAlert[];
+      let promise = this.HawkularAlertsManager.queryAlerts({
+        statuses: 'OPEN',
+        tags: 'resourceId|' + this.resourceId,
+        startTime: this.startTimeStamp,
+        endTime: this.endTimeStamp
+      }).then((data)=> {
+        _.remove(data.alertList, (item) => {
+          switch( item.context.alertType ) {
+            case 'DEPLOYMENT_FAIL' :
+              item['alertType'] = item.context.alertType;
+              return false;
+            default : return true; // ignore non-jvm alert
+          }
+        });
+        alertArray = data.alertList;
+      }, (error) => {
+        return this.ErrorsManager.errorHandler(error, 'Error fetching deployment failure alerts.');
+      });
+
+      this.$q.all([promise]).finally(()=> {
+        this.alertList = alertArray;
+      });
     }
 
     public getResourceList(currentTenantId?:TenantId):void {
-      this.alertList = []; // FIXME: when we have alerts for app server
       let tenantId:TenantId = currentTenantId || this.$rootScope.currentPersona.id;
-      let idParts = this.$routeParams.resourceId.split('~');
+      let idParts = this.resourceId.split('~');
       let feedId = idParts[0];
       this.HawkularInventory.ResourceOfTypeUnderFeed.query({
           environmentId: globalEnvironmentId,
@@ -120,7 +153,7 @@ module HawkularMetrics {
           let promises = [];
           let tmpResourceList = [];
           _.forEach(aResourceList, (res:IResource) => {
-            if (res.id.startsWith(new RegExp(this.$routeParams.resourceId + '~/'))) {
+            if (res.id.startsWith(new RegExp(this.resourceId + '~/'))) {
               tmpResourceList.push(res);
               res.selected = _.result(_.find(this.resourceList, {'id': res.id}), 'selected');
               promises.push(this.HawkularMetric.AvailabilityMetricData(this.$rootScope.currentPersona.id).query({

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
@@ -122,11 +122,11 @@ module HawkularMetrics {
         tags: 'resourceId|' + this.resourceId,
         startTime: this.startTimeStamp,
         endTime: this.endTimeStamp
-      }).then((data)=> {
-        _.remove(data.alertList, (item) => {
+      }).then((data:IHawkularAlertQueryResult)=> {
+        _.remove(data.alertList, (item:IAlert) => {
           switch( item.context.alertType ) {
             case 'DEPLOYMENT_FAIL' :
-              item['alertType'] = item.context.alertType;
+              item.alertType = item.context.alertType;
               return false;
             default : return true; // ignore non-jvm alert
           }

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmDetails.ts
@@ -44,7 +44,6 @@ module HawkularMetrics {
 
     public math = Math;
 
-    public resourceId;
     public alertList;
     public chartHeapData:IMultiDataPoint[];
     public chartNonHeapData:IMultiDataPoint[];
@@ -71,7 +70,6 @@ module HawkularMetrics {
                 private $q:ng.IQService ) {
       $scope.vm = this;
 
-      this.resourceId = this.$routeParams.resourceId;
       this.startTimeStamp = +moment().subtract(($routeParams.timeOffset || 3600000), 'milliseconds');
       this.endTimeStamp = +moment();
       this.chartHeapData = [];
@@ -122,7 +120,7 @@ module HawkularMetrics {
       let jvmArray: IAlert[];
       let jvmPromise = this.HawkularAlertsManager.queryAlerts({
         statuses: 'OPEN',
-        tags: 'resourceId|' + this.resourceId,
+        tags: 'resourceId|' + this.$routeParams.resourceId,
         startTime: this.startTimeStamp,
         endTime: this.endTimeStamp
       }).then((jvmData:IHawkularAlertQueryResult)=> {
@@ -148,14 +146,14 @@ module HawkularMetrics {
 
     public getJvmData():void {
       this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-        'MI~R~[' + this.resourceId + '~~]~MT~WildFly Memory Metrics~Heap Used',
+        'MI~R~[' + this.$routeParams.resourceId + '~~]~MT~WildFly Memory Metrics~Heap Used',
         this.startTimeStamp, this.endTimeStamp, 1).then((resource) => {
           if (resource.length) {
             this['heapUsage'] = resource[0];
           }
         });
       this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-        'MI~R~[' + this.resourceId + '~~]~MT~WildFly Memory Metrics~Heap Max',
+        'MI~R~[' + this.$routeParams.resourceId + '~~]~MT~WildFly Memory Metrics~Heap Max',
         this.startTimeStamp, this.endTimeStamp, 1).then((resource) => {
           if (resource.length) {
             this['heapMax'] = resource[0];
@@ -163,7 +161,7 @@ module HawkularMetrics {
           }
         });
       this.MetricsService.retrieveCounterMetrics(this.$rootScope.currentPersona.id,
-        'MI~R~[' + this.resourceId + '~~]~MT~WildFly Memory Metrics~Accumulated GC Duration',
+        'MI~R~[' + this.$routeParams.resourceId + '~~]~MT~WildFly Memory Metrics~Accumulated GC Duration',
         this.startTimeStamp, this.endTimeStamp, 1).then((resource) => {
           if (resource.length) {
             this['accGCDuration'] = (resource[0].max - resource[0].min);
@@ -177,10 +175,11 @@ module HawkularMetrics {
       let heapPromises = [];
       let tmpChartNonHeapData = [];
       let nonHeapPromises = [];
+      let resourceId:string = this.$routeParams.resourceId;
 
       if (!this.skipChartData['Heap Committed']) {
         let hCommPromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-          'MI~R~[' + this.resourceId + '~~]~MT~WildFly Memory Metrics~Heap Committed',
+          'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Heap Committed',
           this.startTimeStamp, this.endTimeStamp,60);
         heapPromises.push(hCommPromise);
         hCommPromise.then((data) => {
@@ -193,7 +192,7 @@ module HawkularMetrics {
       }
       if (!this.skipChartData['Heap Used']) {
         let hUsedPromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-          'MI~R~[' + this.resourceId + '~~]~MT~WildFly Memory Metrics~Heap Used',
+          'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Heap Used',
           this.startTimeStamp, this.endTimeStamp, 60);
         heapPromises.push(hUsedPromise);
         hUsedPromise.then((data) => {
@@ -206,7 +205,7 @@ module HawkularMetrics {
       }
       if (!this.skipChartData['Heap Max']) {
         let hMaxPromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-          'MI~R~[' + this.resourceId + '~~]~MT~WildFly Memory Metrics~Heap Max',
+          'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Heap Max',
           this.startTimeStamp, this.endTimeStamp, 60);
         heapPromises.push(hMaxPromise);
         hMaxPromise.then((data) => {
@@ -223,7 +222,7 @@ module HawkularMetrics {
 
       if (!this.skipChartData['NonHeap Committed']) {
         let nhCommPromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-          'MI~R~[' + this.resourceId + '~~]~MT~WildFly Memory Metrics~NonHeap Committed',
+          'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~NonHeap Committed',
           this.startTimeStamp, this.endTimeStamp, 60);
         nonHeapPromises.push(nhCommPromise);
         nhCommPromise.then((data) => {
@@ -236,7 +235,7 @@ module HawkularMetrics {
       }
       if (!this.skipChartData['NonHeap Used']) {
         let nhUsedPromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-          'MI~R~[' + this.resourceId + '~~]~MT~WildFly Memory Metrics~NonHeap Used',
+          'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~NonHeap Used',
           this.startTimeStamp, this.endTimeStamp, 60);
         nonHeapPromises.push(nhUsedPromise);
         nhUsedPromise.then((data) => {
@@ -252,7 +251,7 @@ module HawkularMetrics {
       });
 
       this.MetricsService.retrieveCounterRateMetrics(this.$rootScope.currentPersona.id,
-        'MI~R~[' + this.resourceId + '~~]~MT~WildFly Memory Metrics~Accumulated GC Duration',
+        'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Accumulated GC Duration',
         this.startTimeStamp, this.endTimeStamp, 60).then((resource) => {
           if (resource.length) {
             this.chartGCDurationData = MetricsService.formatBucketedChartOutput(resource);

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJvmDetails.ts
@@ -125,13 +125,13 @@ module HawkularMetrics {
         tags: 'resourceId|' + this.resourceId,
         startTime: this.startTimeStamp,
         endTime: this.endTimeStamp
-      }).then((jvmData)=> {
-        _.remove(jvmData.alertList, (item) => {
+      }).then((jvmData:IHawkularAlertQueryResult)=> {
+        _.remove(jvmData.alertList, (item:IAlert) => {
           switch( item.context.alertType ) {
             case 'PHEAP' :
             case 'NHEAP' :
             case 'GARBA' :
-              item['alertType'] = item.context.alertType;
+              item.alertType = item.context.alertType;
               return false;
             default : return true; // ignore non-jvm alert
           }

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerPlatformDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerPlatformDetails.ts
@@ -95,50 +95,6 @@ module HawkularMetrics {
       this.refresh();
     }
 
-  ;
-
-    private getAlerts(metricIdPrefix:string, startTime:TimestampInMillis, endTime:TimestampInMillis):void {
-      let pheapArray:any, nheapArray:any, garbaArray:any;
-      let pheapPromise = this.HawkularAlertsManager.queryAlerts({
-        statuses: 'OPEN',
-        triggerIds: metricIdPrefix + '_platform_mem', startTime: startTime, endTime: endTime
-      }).then((pheapData)=> {
-        _.forEach(pheapData.alertList, (item) => {
-          item['alertType'] = 'P_MEM';
-        });
-        pheapArray = pheapData.alertList;
-      }, (error) => {
-        return this.ErrorsManager.errorHandler(error, 'Error fetching alerts.');
-      });
-
-      let nheapPromise = this.HawkularAlertsManager.queryAlerts({
-        statuses: 'OPEN',
-        triggerIds: metricIdPrefix + '_platform_cpu', startTime: startTime, endTime: endTime
-      }).then((nheapData)=> {
-        _.forEach(nheapData.alertList, (item) => {
-          item['alertType'] = 'PCPU';
-        });
-        nheapArray = nheapData.alertList;
-      }, (error) => {
-        return this.ErrorsManager.errorHandler(error, 'Error fetching alerts.');
-      });
-
-      let garbaPromise = this.HawkularAlertsManager.queryAlerts({
-        statuses: 'OPEN',
-        triggerIds: metricIdPrefix + '_jvm_garba', startTime: startTime, endTime: endTime
-      }).then((garbaData)=> { // TODO
-        _.forEach(garbaData.alertList, (item) => {
-          item['alertType'] = 'GARBA'; // TODO
-        });
-        garbaArray = garbaData.alertList;
-      }, (error) => {
-        return this.ErrorsManager.errorHandler(error, 'Error fetching alerts.');
-      });
-
-      this.$q.all([pheapPromise, nheapPromise, garbaPromise]).finally(()=> {
-        this.alertList = [].concat(pheapArray, nheapArray, garbaArray);
-      });
-    }
 
     private autoRefreshPromise:ng.IPromise<number>;
 
@@ -146,7 +102,6 @@ module HawkularMetrics {
     private autoRefresh(intervalInSeconds:number):void {
       this.autoRefreshPromise = this.$interval(() => {
         this.refresh();
-        this.getAlerts(this.$routeParams.resourceId, this.startTimeStamp, this.endTimeStamp);
       }, intervalInSeconds * 1000);
 
       this.$scope.$on('$destroy', () => {
@@ -160,7 +115,6 @@ module HawkularMetrics {
       this.getMemoryChartData();
       this.getFSChartData();
       this.getCpuChartDetailData();
-      this.getAlerts(this.$routeParams.resourceId, this.startTimeStamp, this.endTimeStamp);
     }
 
     public getFileSystems():any {

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebDetails.ts
@@ -128,13 +128,13 @@ module HawkularMetrics {
         tags: 'resourceId|' + this.resourceId,
         startTime: this.startTimeStamp,
         endTime: this.endTimeStamp
-      }).then((webData)=> {
-        _.remove(webData.alertList, (item) => {
+      }).then((webData:IHawkularAlertQueryResult)=> {
+        _.remove(webData.alertList, (item:IAlert) => {
           switch( item.context.alertType ) {
             case 'ACTIVE_SESSIONS' :
             case 'EXPIRED_SESSIONS' :
             case 'REJECTED_SESSIONS' :
-              item['alertType'] = item.context.alertType;
+              item.alertType = item.context.alertType;
               return false;
             default : return true; // ignore non-web alert
           }

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerWebDetails.ts
@@ -48,7 +48,6 @@ module HawkularMetrics {
     public static DEFAULT_REJECTED_SESSIONS_THRESHOLD = 15;
 
     public alertList;
-    public resourceId;
     public activeWebSessions:number = 0;
     public requestTime:number = 0;
     public requestCount:number = 0;
@@ -73,7 +72,6 @@ module HawkularMetrics {
                 private MetricsService:IMetricsService) {
       $scope.vm = this;
 
-      this.resourceId = this.$routeParams.resourceId;
       this.startTimeStamp = +moment().subtract(($routeParams.timeOffset || 3600000), 'milliseconds');
       this.endTimeStamp = +moment();
 
@@ -125,7 +123,7 @@ module HawkularMetrics {
       let webArray: IAlert[];
       let webPromise = this.HawkularAlertsManager.queryAlerts({
         statuses: 'OPEN',
-        tags: 'resourceId|' + this.resourceId,
+        tags: 'resourceId|' + this.$routeParams.resourceId,
         startTime: this.startTimeStamp,
         endTime: this.endTimeStamp
       }).then((webData:IHawkularAlertQueryResult)=> {
@@ -150,18 +148,20 @@ module HawkularMetrics {
     }
 
     public getWebData():void {
+      let resourceId:string = this.$routeParams.resourceId;
+
       this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-        `MI~R~[${this.resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions`,
+        `MI~R~[${resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions`,
         this.startTimeStamp, this.endTimeStamp, 1).then((resource) => {
           this.activeWebSessions = resource[0].avg;
         });
       this.MetricsService.retrieveCounterMetrics(this.$rootScope.currentPersona.id,
-        `MI~R~[${this.resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time`,
+        `MI~R~[${resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Time`,
         this.startTimeStamp, this.endTimeStamp, 1).then((resource) => {
           this.requestTime = resource[0].max - resource[0].min;
         });
       this.MetricsService.retrieveCounterMetrics(this.$rootScope.currentPersona.id,
-        `MI~R~[${this.resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count`,
+        `MI~R~[${resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Servlet Request Count`,
         this.startTimeStamp, this.endTimeStamp, 1).then((resource) => {
           this.requestCount = resource[0].max - resource[0].min;
         });
@@ -170,10 +170,11 @@ module HawkularMetrics {
     public getWebChartData():void {
       let tmpChartWebSessionData = [];
       let promises = [];
+      let resourceId:string = this.$routeParams.resourceId;
 
       if (!this.skipChartData['Active Sessions']) {
         let activeSessionsPromise = this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-          `MI~R~[${this.resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions`,
+          `MI~R~[${resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions`,
           this.startTimeStamp, this.endTimeStamp, 60);
         promises.push(activeSessionsPromise);
         activeSessionsPromise.then((data) => {
@@ -186,7 +187,7 @@ module HawkularMetrics {
       }
       if (!this.skipChartData['Expired Sessions']) {
         let expSessionsPromise = this.MetricsService.retrieveCounterMetrics(this.$rootScope.currentPersona.id,
-          `MI~R~[${this.resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions`,
+          `MI~R~[${resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions`,
           this.startTimeStamp, this.endTimeStamp, 60);
         promises.push(expSessionsPromise);
         expSessionsPromise.then((data) => {
@@ -199,7 +200,7 @@ module HawkularMetrics {
       }
       if (!this.skipChartData['Rejected Sessions']) {
         let rejSessionsPromise = this.MetricsService.retrieveCounterMetrics(this.$rootScope.currentPersona.id,
-          `MI~R~[${this.resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions`,
+          `MI~R~[${resourceId}~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions`,
           this.startTimeStamp, this.endTimeStamp, 60);
         promises.push(rejSessionsPromise);
         rejSessionsPromise.then((data) => {

--- a/console/src/main/scripts/plugins/metrics/ts/metricsAlerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsAlerts.ts
@@ -250,7 +250,6 @@ module HawkularMetrics {
     public static  $inject = ['$scope', 'HawkularAlertsManager', 'ErrorsManager', 'NotificationsService', '$log', '$q',
       '$rootScope', '$routeParams', '$modal', '$interval', 'HkHeaderParser'];
 
-    private resourceId:ResourceId;
     public alertList:any = [];
     public openSetup:any;
     public isResolvingAll:boolean = false;
@@ -278,8 +277,6 @@ module HawkularMetrics {
       this.$log.debug('querying data');
       this.$log.debug('$routeParams', $routeParams);
 
-      this.resourceId = $routeParams.resourceId;
-
       this.alertsTimeOffset = $routeParams.timeOffset || 3600000;
       // If the end time is not specified in URL use current time as end time
       this.alertsTimeEnd = $routeParams.endTime ? $routeParams.endTime : (new Date()).getTime();
@@ -302,7 +299,8 @@ module HawkularMetrics {
       this.alertsTimeEnd = this.$routeParams.endTime ? this.$routeParams.endTime : (new Date()).getTime();
       this.alertsTimeStart = this.alertsTimeEnd - this.alertsTimeOffset;
 
-      let triggerIds = this.resourceId + '_trigger_avail,' + this.resourceId + '_trigger_thres';
+      let resourceId:string = this.$routeParams.resourceId;
+      let triggerIds:string = resourceId + '_trigger_avail,' + resourceId + '_trigger_thres';
 
       this.HawkularAlertsManager.queryAlerts({
         statuses: 'OPEN', triggerIds: triggerIds, startTime: this.alertsTimeStart,

--- a/console/src/main/scripts/plugins/metrics/ts/metricsAppServerDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsAppServerDetails.ts
@@ -26,7 +26,6 @@ module HawkularMetrics {
     public static  $inject = ['$rootScope', '$scope', '$route', '$routeParams', '$q', 'HawkularOps',
       'NotificationsService', 'HawkularInventory', 'HawkularAlertsManager', '$log'];
 
-    public resourceId:string;
     public resourcePath:string;
     public jdrGenerating:boolean;
     public hasGeneratedSuccessfully:boolean;
@@ -55,8 +54,6 @@ module HawkularMetrics {
         this.resourcePath = resource.path;
         this.$rootScope.resourcePath = this.resourcePath;
       });
-
-      this.resourceId = this.$routeParams.resourceId;
 
       $scope.tabs = this;
 
@@ -142,17 +139,18 @@ module HawkularMetrics {
 
       let defaultEmailPromise = this.HawkularAlertsManager.addEmailAction(defaultEmail);
 
+      let resourceId:string = this.$routeParams.resourceId;
+
       // JVM TRIGGERS
 
-      let heapTriggerPromise = this.HawkularAlertsManager.existTrigger(this.resourceId + '_jvm_pheap').then(() => {
+      let heapTriggerPromise = this.HawkularAlertsManager.existTrigger(resourceId + '_jvm_pheap').then(() => {
         this.$log.debug('Heap Used trigger exists, nothing to do');
       }, () => {
         // Jvm trigger doesn't exist, need to create one
         let low = AppServerJvmDetailsController.MAX_HEAP * 0.2;
         let high = AppServerJvmDetailsController.MAX_HEAP * 0.8;
 
-        let triggerId:string = this.resourceId + '_jvm_pheap';
-        let resourceId:string = triggerId.slice(0, -10);
+        let triggerId:string = resourceId + '_jvm_pheap';
         let dataId:string = 'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Heap Used';
         let heapMaxId:string = 'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Heap Max';
 
@@ -221,15 +219,14 @@ module HawkularMetrics {
         });
       });
 
-      let nonHeapTriggerPromise = this.HawkularAlertsManager.existTrigger(this.resourceId + '_jvm_nheap').then(() => {
+      let nonHeapTriggerPromise = this.HawkularAlertsManager.existTrigger(resourceId + '_jvm_nheap').then(() => {
         this.$log.debug('Non Heap Used trigger exists, nothing to do');
       }, () => {
         // Jvm trigger doesn't exist, need to create one
         let low = AppServerJvmDetailsController.MAX_HEAP * 0.2;
         let high = AppServerJvmDetailsController.MAX_HEAP * 0.8;
 
-        let triggerId:string = this.resourceId + '_jvm_nheap';
-        let resourceId:string = triggerId.slice(0, -10);
+        let triggerId:string = resourceId + '_jvm_nheap';
         let dataId:string = 'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~NonHeap Used';
         let heapMaxId:string = 'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Heap Max';
 
@@ -298,12 +295,11 @@ module HawkularMetrics {
         });
       });
 
-      let garbageTriggerPromise = this.HawkularAlertsManager.existTrigger(this.resourceId + '_jvm_garba').then(() => {
+      let garbageTriggerPromise = this.HawkularAlertsManager.existTrigger(resourceId + '_jvm_garba').then(() => {
         this.$log.debug('GC trigger exists, nothing to do');
       }, () => {
         // Jvm trigger doesn't exist, need to create one
-        let triggerId:string = this.resourceId + '_jvm_garba';
-        let resourceId:string = triggerId.slice(0, -10);
+        let triggerId:string = resourceId + '_jvm_garba';
         let dataId:string = 'MI~R~[' + resourceId + '~~]~MT~WildFly Memory Metrics~Accumulated GC Duration';
 
         let fullTrigger = {
@@ -358,13 +354,12 @@ module HawkularMetrics {
       // WEB SESSION TRIGGERS
 
       let activeSessionsTriggerPromise = this.HawkularAlertsManager
-        .existTrigger(this.resourceId + '_web_active_sessions').then(() => {
+        .existTrigger(resourceId + '_web_active_sessions').then(() => {
           this.$log.debug('Active Web Sessions trigger exists, nothing to do');
         }, () => {
           // Active Web Sessions trigger doesn't exist, need to create one
 
-          let triggerId:string = this.resourceId + '_web_active_sessions';
-          let resourceId:string = triggerId.slice(0, -20);
+          let triggerId:string = resourceId + '_web_active_sessions';
           let dataId:string = 'MI~R~[' + resourceId +
             '~~]~MT~WildFly Aggregated Web Metrics~Aggregated Active Web Sessions';
 
@@ -421,13 +416,12 @@ module HawkularMetrics {
         });
 
       let expiredSessionsTriggerPromise = this.HawkularAlertsManager
-        .existTrigger(this.resourceId + '_web_expired_sessions').then(() => {
+        .existTrigger(resourceId + '_web_expired_sessions').then(() => {
           this.$log.debug('Expired Web Sessions trigger exists, nothing to do');
         }, () => {
           // Active Web Sessions trigger doesn't exist, need to create one
 
-          let triggerId:string = this.resourceId + '_web_expired_sessions';
-          let resourceId:string = triggerId.slice(0, -21);
+          let triggerId:string = resourceId + '_web_expired_sessions';
           let dataId:string = 'MI~R~[' + resourceId +
             '~~]~MT~WildFly Aggregated Web Metrics~Aggregated Expired Web Sessions';
 
@@ -482,13 +476,12 @@ module HawkularMetrics {
 
 
       let rejectedSessionsTriggerPromise = this.HawkularAlertsManager
-        .existTrigger(this.resourceId + '_web_rejected_sessions').then(() => {
+        .existTrigger(resourceId + '_web_rejected_sessions').then(() => {
           this.$log.debug('Rejected Web Sessions trigger exists, nothing to do');
         }, () => {
           // Rejected Web Sessions trigger doesn't exist, need to create one
 
-          let triggerId:string = this.resourceId + '_web_rejected_sessions';
-          let resourceId:string = triggerId.slice(0, -22);
+          let triggerId:string = resourceId + '_web_rejected_sessions';
           let dataId:string = 'MI~R~[' + resourceId +
             '~~]~MT~WildFly Aggregated Web Metrics~Aggregated Rejected Web Sessions';
 
@@ -544,14 +537,13 @@ module HawkularMetrics {
       // FAILED DEPLOYMENT TRIGGER
 
       let failedDeploymentTriggerPromise = this.HawkularAlertsManager
-        .existTrigger(this.resourceId + '_failed_deployment').then(() => {
+        .existTrigger(resourceId + '_failed_deployment').then(() => {
           this.$log.debug('Failed Deployment trigger exists, nothing to do');
         }, () => {
           // Failed Deployment trigger doesn't exist, need to create one
 
-          let triggerId:string = this.resourceId + '_failed_deployment';
-          let resourceId:string = triggerId.slice(0, -18);
-          let dataId:string = this.resourceId + '_DeployApplicationResponse';
+          let triggerId:string = resourceId + '_failed_deployment';
+          let dataId:string = resourceId + '_DeployApplicationResponse';
 
           let fullTrigger = {
             trigger: {

--- a/console/src/main/scripts/plugins/metrics/ts/metricsAvailability.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsAvailability.ts
@@ -125,7 +125,7 @@ module HawkularMetrics {
       });
     }
 
-    public static min(a:number, b:number):number {
+    public min(a:number, b:number):number {
       return Math.min(a, b);
     }
 

--- a/console/src/main/scripts/plugins/metrics/ts/metricsAvailability.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsAvailability.ts
@@ -105,8 +105,8 @@ module HawkularMetrics {
       let promise = this.HawkularAlertsManager.queryAlerts({
         statuses: 'OPEN',
         tags: 'resourceId|' + resourceId, startTime: startTime, endTime: endTime
-      }).then((data)=> {
-        _.remove(data.alertList, (item) => {
+      }).then((data:IHawkularAlertQueryResult)=> {
+        _.remove(data.alertList, (item:IAlert) => {
           switch (item.context.alertType) {
             case 'PINGAVAIL' :
               item['alertType'] = item.context.alertType;

--- a/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
@@ -187,6 +187,11 @@ module HawkularMetrics {
         controller: 'ThresholdTriggerSetupController',
         controllerAs: 'tc'
       }).
+      when('/hawkular-ui/alerts-center-triggers/event/:triggerId', {
+        templateUrl: 'plugins/metrics/html/triggers/event.html',
+        controller: 'EventTriggerSetupController',
+        controllerAs: 'tc'
+      }).
       when('/hawkular-ui/agent-installer/view', {templateUrl: 'plugins/metrics/html/agent-installer.html'}).
       otherwise({redirectTo: '/hawkular-ui/app/app-list'});
   }]);

--- a/console/src/main/scripts/plugins/metrics/ts/metricsResponse.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsResponse.ts
@@ -141,7 +141,7 @@ module HawkularMetrics {
       return this.resourceId + '.status.duration';
     }
 
-    public static min(a:number, b:number):number {
+    public min(a:number, b:number):number {
       return Math.min(a, b);
     }
 

--- a/console/src/main/scripts/plugins/metrics/ts/metricsResponse.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsResponse.ts
@@ -88,11 +88,11 @@ module HawkularMetrics {
       let promise = this.HawkularAlertsManager.queryAlerts({
         statuses: 'OPEN',
         tags: 'resourceId|' + resourceId, startTime: startTime, endTime: endTime
-      }).then((data)=> {
-        _.remove(data.alertList, (item) => {
+      }).then((data:IHawkularAlertQueryResult)=> {
+        _.remove(data.alertList, (item:IAlert) => {
           switch (item.context.alertType) {
             case 'PINGRESPONSE' :
-              item['alertType'] = item.context.alertType;
+              item.alertType = item.context.alertType;
               return false;
             default :
               return true; // ignore non-response-time alert

--- a/console/src/main/scripts/plugins/metrics/ts/metricsTypes.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsTypes.ts
@@ -157,13 +157,17 @@ module HawkularMetrics {
   }
 
   export interface ITriggerContext {
+    alertType: string;
     resourceName: string;
     resourcePath: string;
     resourceType: string;
     triggerType: string;
+    triggerTypeProperty1: string;
+    triggerTypeProperty2: string;
   }
 
   export interface IAlertTrigger {
+    actions: any;
     autoDisable: boolean;
     autoEnable: boolean;
     autoResolve: boolean;
@@ -178,6 +182,7 @@ module HawkularMetrics {
     name: string;
     orphan: boolean;
     severity: string; /// @todo: change to enum
+    tags: any;
     tenantId: TenantId;
     triggerId: TriggerId;
     ///@todo: ignoring actions for now

--- a/console/src/main/scripts/plugins/metrics/ts/metricsTypes.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsTypes.ts
@@ -127,11 +127,16 @@ module HawkularMetrics {
     feedId: FeedId;
     environmentId: Environment;
     state: string;
-    selected: boolean;
     tenantId: TenantId;
     updateTimestamp: TimestampInMillis;
     properties: IResourceProperties;
     type: IResourceType;
+
+    // for console use
+    alertList: IAlert[];
+    availableCount: number;
+    inUseCount: number;
+    selected: boolean;
   }
 
   export interface IAvailResource {
@@ -203,6 +208,9 @@ module HawkularMetrics {
     // UI may augment this by adding a 'selected' property for list results
     // so we can use the original data structure as-is
     selected?: boolean;
+
+    // UI stores an 'alertType' to benefit display
+    alertType:string;
   }
 
 }

--- a/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
@@ -348,10 +348,6 @@ module HawkularMetrics {
               for (let j = 0; j < serverAlert.evalSets.length; j++) {
                 let evalItem = serverAlert.evalSets[j][0];
 
-                if (serverAlert.trigger.name === 'JVM Heap Used') {
-                  console.log('evalItem:' + evalItem.value);
-                }
-
                 if (!consoleAlert.start && evalItem.dataTimestamp) {
                   consoleAlert.start = evalItem.dataTimestamp;
                 }

--- a/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
@@ -92,7 +92,7 @@ module HawkularMetrics {
      * @param criteria - Filter for alerts query
      * @returns {ng.IPromise} with a list of Alerts
      */
-    queryAlerts(criteria?: IHawkularAlertCriteria):
+    queryAlerts(criteria?:IHawkularAlertCriteria):
       ng.IPromise<IHawkularAlertQueryResult>;
 
     /**
@@ -100,14 +100,14 @@ module HawkularMetrics {
      * @desc Single alert fetch
      * @param alertId - Alert to query
      */
-    getAlert(alertId: string): ng.IPromise<IAlert>;
+    getAlert(alertId:string): ng.IPromise<IAlert>;
 
     /**
      * @name queryActionsHistory
      * @desc Fetch Actions from history with different criterias
      * @param criteria - Filter for actions query
      */
-    queryActionsHistory(criteria?: IHawkularActionCriteria): ng.IPromise<any>;
+    queryActionsHistory(criteria?:IHawkularActionCriteria): ng.IPromise<any>;
 
     /**
      * @name resolveAlerts
@@ -182,7 +182,7 @@ module HawkularMetrics {
      * @param criteria - Filter for triggers query
      * @returns {ng.IPromise} with a list of Triggers
      */
-    queryTriggers(criteria?: IHawkularTriggerCriteria):
+    queryTriggers(criteria?:IHawkularTriggerCriteria):
       ng.IPromise<IHawkularTriggerQueryResult>;
 
     /**
@@ -253,18 +253,18 @@ module HawkularMetrics {
                 private ErrorsManager:IErrorsManager) {
     }
 
-    public queryAlerts(criteria: IHawkularAlertCriteria):ng.IPromise<IHawkularAlertQueryResult> {
+    public queryAlerts(criteria:IHawkularAlertCriteria):ng.IPromise<IHawkularAlertQueryResult> {
       let alertList = [];
       let headers;
 
       /* Format of Alerts:
 
        alert: {
-        type: 'THRESHOLD' or 'AVAILABILITY',
-        avg: Average value based on the evalSets 'values',
-        start: The time of the first data ('dataTimestamp') in evalSets,
-        threshold: The threshold taken from condition.threshold,
-        end: The time when the alert was sent ('ctime')
+       type: 'THRESHOLD' or 'AVAILABILITY',
+       avg: Average value based on the evalSets 'values',
+       start: The time of the first data ('dataTimestamp') in evalSets,
+       threshold: The threshold taken from condition.threshold,
+       end: The time when the alert was sent ('ctime')
        }
 
        */
@@ -343,44 +343,48 @@ module HawkularMetrics {
 
           if (serverAlert.evalSets) {
 
-            console.log( serverAlert.trigger.name + ': ' + serverAlert.evalSets );
+            if (serverAlert.context.triggerType !== 'Event') {
 
-            for (let j = 0; j < serverAlert.evalSets.length; j++) {
-              let evalItem = serverAlert.evalSets[j][0];
+              for (let j = 0; j < serverAlert.evalSets.length; j++) {
+                let evalItem = serverAlert.evalSets[j][0];
 
-              if (serverAlert.trigger.name === 'JVM Heap Used') {
-                console.log('evalItem:' + evalItem.value);
-              }
-
-              if (!consoleAlert.start && evalItem.dataTimestamp) {
-                consoleAlert.start = evalItem.dataTimestamp;
-              }
-
-              if (!consoleAlert.threshold && evalItem.condition.threshold) {
-                consoleAlert.threshold = evalItem.condition.threshold;
-              }
-
-              if (!consoleAlert.type && evalItem.condition.type) {
-                consoleAlert.type = evalItem.condition.type;
-              }
-
-              let momentAlert = this.$moment(consoleAlert.end);
-
-              if (momentAlert.year() === momentNow.year()) {
-                consoleAlert.isThisYear = true;
-                if (momentAlert.dayOfYear() === momentNow.dayOfYear()) {
-                  consoleAlert.isToday = true;
+                if (serverAlert.trigger.name === 'JVM Heap Used') {
+                  console.log('evalItem:' + evalItem.value);
                 }
+
+                if (!consoleAlert.start && evalItem.dataTimestamp) {
+                  consoleAlert.start = evalItem.dataTimestamp;
+                }
+
+                if (!consoleAlert.threshold && evalItem.condition.threshold) {
+                  consoleAlert.threshold = evalItem.condition.threshold;
+                }
+
+                if (!consoleAlert.type && evalItem.condition.type) {
+                  consoleAlert.type = evalItem.condition.type;
+                }
+
+                let momentAlert = this.$moment(consoleAlert.end);
+
+                if (momentAlert.year() === momentNow.year()) {
+                  consoleAlert.isThisYear = true;
+                  if (momentAlert.dayOfYear() === momentNow.dayOfYear()) {
+                    consoleAlert.isToday = true;
+                  }
+                }
+
+                sum += ( evalItem.value ? evalItem.value : evalItem.value1 );  // handle compare conditions
+                count++;
               }
 
-              sum += ( evalItem.value !== undefined ? evalItem.value : evalItem.value1 );  // handle compare conditions
-              count++;
+              consoleAlert.avg = sum / count;
+              consoleAlert.durationTime = consoleAlert.end - consoleAlert.start;
+
+            } else {
+              let evalItem = serverAlert.evalSets[0][0];
+              let event = evalItem.value;
+              consoleAlert.message = event.context.Message;
             }
-
-            consoleAlert.avg = sum / count;
-
-            consoleAlert.durationTime = consoleAlert.end - consoleAlert.start;
-
           }
 
           alertList.push(consoleAlert);
@@ -395,11 +399,11 @@ module HawkularMetrics {
         });
     }
 
-    public getAlert(alertId: string): ng.IPromise<IAlert> {
+    public getAlert(alertId:string):ng.IPromise<IAlert> {
       return this.HawkularAlert.Alert.get({alertId: alertId}).$promise;
     }
 
-    public queryActionsHistory(criteria?: IHawkularActionCriteria): ng.IPromise<any> {
+    public queryActionsHistory(criteria?:IHawkularActionCriteria):ng.IPromise<any> {
       let actionHistoryList = [];
       let headers;
       let queryParams = {};
@@ -460,7 +464,7 @@ module HawkularMetrics {
             actionsList: actionHistoryList,
             headers: headers
           };
-      });
+        });
     }
 
     public resolveAlerts(resolvedAlerts:any):ng.IPromise<any> {
@@ -635,7 +639,7 @@ module HawkularMetrics {
       return this.$q.all(Array.prototype.concat(emailPromise, dampeningPromises, conditionPromises));
     }
 
-    public queryTriggers(criteria: IHawkularTriggerCriteria):ng.IPromise<IHawkularTriggerQueryResult> {
+    public queryTriggers(criteria:IHawkularTriggerCriteria):ng.IPromise<IHawkularTriggerQueryResult> {
       let triggerList = [];
       let headers;
 

--- a/console/src/main/scripts/plugins/metrics/ts/triggers/eventTrigger.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/triggers/eventTrigger.ts
@@ -1,0 +1,68 @@
+///
+/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// and other contributors as indicated by the @author tags.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+/// <reference path="../metricsPlugin.ts"/>
+/// <reference path="../../includes.ts"/>
+/// <reference path="../services/alertsManager.ts"/>
+/// <reference path="../services/errorsManager.ts"/>
+
+module HawkularMetrics {
+
+  export class EventTriggerSetupController extends TriggerSetupController {
+
+    loadTrigger(triggerId:string):Array<ng.IPromise<any>> {
+
+      let triggerPromise = this.HawkularAlertsManager.getTrigger(triggerId).then(
+        (triggerData) => {
+
+          this.fullTrigger = triggerData;
+
+          this.adm.trigger = {};
+          // updateable
+          this.adm.trigger['description'] = triggerData.trigger.description;
+          this.adm.trigger['enabled'] = triggerData.trigger.enabled;
+          this.adm.trigger['name'] = triggerData.trigger.name;
+          this.adm.trigger['severity'] = triggerData.trigger.severity;
+
+          this.adm.trigger['email'] = triggerData.trigger.actions.email[0];
+
+          // presentation
+          this.adm.trigger['context'] = triggerData.trigger.context;
+        });
+
+      return [triggerPromise];
+    }
+
+    saveTrigger(errorCallback):Array<ng.IPromise<any>> {
+
+      let updatedFullTrigger = angular.copy(this.fullTrigger);
+      updatedFullTrigger.trigger.enabled = this.adm.trigger.enabled;
+      updatedFullTrigger.trigger.name = this.adm.trigger.name;
+      updatedFullTrigger.trigger.description = this.adm.trigger.description;
+      updatedFullTrigger.trigger.severity = this.adm.trigger.severity;
+
+      updatedFullTrigger.trigger.actions.email[0] = this.adm.trigger.email;
+
+      let triggerSavePromise = this.HawkularAlertsManager.updateTrigger(updatedFullTrigger, errorCallback,
+        this.fullTrigger);
+
+      return [triggerSavePromise];
+    }
+  }
+
+  _module.controller('EventTriggerSetupController', EventTriggerSetupController);
+}

--- a/modules/avail-creator/pom.xml
+++ b/modules/avail-creator/pom.xml
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>org.hawkular.bus</groupId>
       <artifactId>hawkular-bus-common</artifactId>
+      <scope>provided</scope> <!-- the nest provides this -->
     </dependency>
 
     <dependency>

--- a/modules/pinger/pom.xml
+++ b/modules/pinger/pom.xml
@@ -61,6 +61,7 @@
     <dependency>
       <groupId>org.hawkular.bus</groupId>
       <artifactId>hawkular-bus-common</artifactId>
+      <scope>provided</scope> <!-- the nest provides this -->
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,10 +87,10 @@
     <version.gnu.getopt>1.0.13</version.gnu.getopt>
     <version.org.hawkular.accounts>1.1.2.Final</version.org.hawkular.accounts>
     <version.org.hawkular.agent>0.13.4.Final</version.org.hawkular.agent>
-    <version.org.hawkular.alerts>0.6.0.Final</version.org.hawkular.alerts>
-    <version.org.hawkular.bus>0.7.2.Final</version.org.hawkular.bus>
+    <version.org.hawkular.alerts>0.7.0-SRC-revision-23092b8d9b7b526bde477b6d0ec8d4119e38a1ca</version.org.hawkular.alerts>
+    <version.org.hawkular.bus>0.7.3.Final-SRC-revision-1af5bac4e32e26804b39ed6c6aa8fec66fdd2cf0</version.org.hawkular.bus>
     <version.org.hawkular.commons>0.2.3.Final</version.org.hawkular.commons>
-    <version.org.hawkular.cmdgw>0.10.3.Final</version.org.hawkular.cmdgw>
+    <version.org.hawkular.cmdgw>0.10.4.Final-SRC-revision-026a46590f53179096f794657d9c6b813313f297</version.org.hawkular.cmdgw>
     <version.org.hawkular.metrics>0.9.0.Final</version.org.hawkular.metrics>
     <version.org.hawkular.inventory>0.8.1.Final</version.org.hawkular.inventory>
     <version.org.keycloak>1.6.1.Final</version.org.keycloak>


### PR DESCRIPTION
Add alert generation for failed deployments.
- New src-deps versions for component enhancements to support this
  - with mazz, enhanced bus-commons with better classloading/deserialization support for MDBs
  - with mazz, enhanced command-gateway to support multiple commands on ws responses, now can notify UI and put a response on the bus
  - enhanced alerts to consume ws deploy app response messages on bus and generate events
- Added new trigger definition on app-servers to fire on a failed deployment event
  - note, also storing successful deployment events for future use/display
- Added new UI support for 'Event' trigger-type and DEPLOYMENT_FAIL alert-type

Also:
- fixed time-window bug in getAlerts query for some trigger types
- make bus-commons dep provided (by nest) for pinger
- make bus-commons dep provided (by nest) for avail-creator