### PR TITLE
Update Bower to version 1.6.3.

### DIFF
--- a/console/src/main/scripts/package.json
+++ b/console/src/main/scripts/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2",
   "private": true,
   "devDependencies": {
-    "bower": "1.4.1",
+    "bower": "1.6.3",
     "del": "1.2.1",
     "event-stream": "3.3.1",
     "gulp": "3.9.0",


### PR DESCRIPTION
It seems something started causing issues with non-numeric bower versions.