### PR TITLE
Replace truncate libraries with single custom filter

### DIFF
--- a/console/src/main/scripts/bower.json
+++ b/console/src/main/scripts/bower.json
@@ -35,8 +35,6 @@
     "moment": "2.10.3",
     "patternfly": "2.5.0",
     "keycloak": "1.3.1",
-    "angular-truncate": "sparkalow/angular-truncate",
-    "angular-smart-truncate": "1.0.2",
     "angular-wizard": "0.5.5",
     "ng-clip": "0.2.6",
     "zeroclipboard": "2.2.0"

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
@@ -20,7 +20,7 @@
         <div class="card-pf">
           <div class="card-pf-heading">
             <h2 class="card-pf-title">
-              {{acd.description | characters: 55}}
+              {{acd.description | truncate: 55}}
             </h2>
           </div>
           <div class="card-pf-body">

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-list.html
@@ -79,9 +79,9 @@
             <td><input type="checkbox" ng-checked="alert.selected"/></td>
             <td ng-class="{'hk-bold': alert.status === 'OPEN'}" class="text-nowrap">{{alert.status|firstUpper}} <i ng-show="(alert.notes.length > 0)" class="fa fa-comment-o" tooltip="With comments" tooltip-trigger tooltip-placement="top"></i></td>
             <td>{{alert.severity|firstUpper}}</td>
-            <td>{{alert.trigger.description| characters: 50}}</td>
+            <td>{{alert.trigger.description| truncate: 50}}</td>
             <td>{{alert.ctime | date:'d MMM yyyy, HH:mm'}}</td>
-            <td>{{alert.context.resourceName | truncate: 30}}</td>
+            <td>{{alert.context.resourceName | truncate: 30 : false : 'middle'}}</td>
             <td><a class="btn btn-link"><i class="fa fa-chevron-circle-right fa-lg"
                                            tooltip="View Details" tooltip-trigger tooltip-placement="top"
                                            ng-click="ac.showDetailPage(alert.id)">

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-triggers.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-triggers.html
@@ -68,7 +68,8 @@
             <td><input type="checkbox" ng-checked="trigger.selected"/></td>
             <td>{{trigger.name}}</td>
             <td>{{trigger.description}}</td>
-            <td><a ng-href="{{act.getResourceRoute(trigger)}}">{{trigger.context.resourceName|truncate: 30}}</a></td>
+            <td><a ng-href="{{act.getResourceRoute(trigger)}}">
+              {{trigger.context.resourceName | truncate: 30 : false : 'middle'}}</a></td>
             <td>{{trigger.severity|firstUpper}}</td>
             <td>{{trigger.enabled ? "Enabled" : "Disabled"}}</td>
             <td>{{trigger.actions.email.length}} <i class="fa fa-envelope-o"></i></td>

--- a/console/src/main/scripts/plugins/metrics/html/partials/trigger-alerts-sidebar.html
+++ b/console/src/main/scripts/plugins/metrics/html/partials/trigger-alerts-sidebar.html
@@ -12,7 +12,7 @@
               <i class="fa fa-exclamation-triangle hk-warning"></i>
             </div>
             <div class="hk-info-container">
-              <div class="hk-info-heading">{{alert.trigger.description | characters: 50 }}</div>
+              <div class="hk-info-heading">{{alert.trigger.description | truncate: 50}}</div>
               <p class="hk-info-info">{{alert.ctime | date:'d MMM yyyy, HH:mm'}}</p>
             </div>
             <div class="hk-icon-container">

--- a/console/src/main/scripts/plugins/metrics/ts/filters/truncateFilter.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/filters/truncateFilter.ts
@@ -1,0 +1,59 @@
+///
+/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// and other contributors as indicated by the @author tags.
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+/// <reference path="../metricsPlugin.ts"/>
+/// <reference path="../../includes.ts"/>
+
+
+module HawkularMetrics {
+
+  // {{ "some text" | truncate : <length> : <words> : <left|right|middle> | <separator> }}
+
+  _module.filter('truncate', () => {
+    return (input, length, keepWords, where, separator) => {
+
+      let DEFAULT_LENGTH = 15;
+      let SEPARATOR = separator || '...';
+      let SEP_LENGTH = SEPARATOR.length;
+
+      length = length || DEFAULT_LENGTH;
+
+      if (!input || input.length < (SEP_LENGTH + 2) || input.length <= length || length <= 1) {
+        return input;
+      }
+
+      let right = where === 'right';
+      let middle = where === 'middle';
+      let left = !where || (!right && !middle);
+
+      let start = left ? length - SEP_LENGTH : (right ? 0 : (Math.round((length - SEP_LENGTH) / 2)));
+      if (keepWords && !right) {
+        start = input.lastIndexOf(' ', start);
+      }
+      let end = right ? -length + SEP_LENGTH : (left ? input.length : 0-(length - SEP_LENGTH - start));
+      if (keepWords && !left) {
+        end = input.indexOf(' ', input.length - Math.abs(end) - 1) + 1;
+      }
+
+      let leftText = input.slice(0, start);
+      let rightText = end ? input.slice(end) : '';
+
+      return leftText + SEPARATOR + rightText;
+    };
+  });
+
+}

--- a/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
@@ -22,8 +22,7 @@ module HawkularMetrics {
 
   export let _module = angular.module(HawkularMetrics.pluginName, ['ngResource', 'ngAnimate', 'ui.select',
     'hawkular.services', 'ui.bootstrap', 'topbar', 'patternfly.select', 'angular-momentjs', 'angular-md5', 'toastr',
-    'infinite-scroll', 'mgo-angular-wizard', 'truncate', '500tech.smart-truncate', 'hawkular.charts', 'ngClipboard',
-    'patternfly.filters']);
+    'infinite-scroll', 'mgo-angular-wizard', 'hawkular.charts', 'ngClipboard', 'patternfly.filters']);
 
   _module.config(['$compileProvider', function ($compileProvider) {
     //disable debug info


### PR DESCRIPTION
Filter usage:
{{ "some text" | truncate : <length> : <words> : <left|right|middle> | <separator> }}

- length: the truncated size (defaults to 15)
- words: keep words intact (defaults to false)
- left|right|middle: where to truncate (defaults to left)
- separator: the separator char/string (defaults to '...')