### PR TITLE
Use resources "name" instead of playing with "id"

### DIFF
--- a/console/src/main/scripts/bower.json
+++ b/console/src/main/scripts/bower.json
@@ -24,7 +24,7 @@
     "ngInfiniteScroll": "1.2.1",
     "bootstrap-select": "1.6",
     "hawkular-charts": "hawkular/hawkular-charts#0b73da1",
-    "hawkular-ui-services": "hawkular/hawkular-ui-services#406ca4e",
+    "hawkular-ui-services": "hawkular/hawkular-ui-services#8ffdbe6",
     "hawtio-core-navigation": "2.0.51",
     "hawtio-core": "2.0.18",
     "hawtio-template-cache": "2.0.4",

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-deployments.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-deployments.html
@@ -132,7 +132,7 @@
                 <td class="state" ng-show="res.state === 'down'"><i class="fa fa-square"></i> Stopped</td>
                 <td class="state" ng-show="res.state === 'unknown'"><i class="fa fa-times-circle-o"></i> Failed</td>
                 <td class="state" ng-hide="res.state"><i class="fa fa-chain-broken"></i> Unknown</td>
-                <td><strong>{{res.name | limitTo : (res.name.length-13) : 12}}</strong>
+                <td><strong>{{res.name}}</strong>
                   <span ng-show="false">({{res.name | limitTo : (res.name.length-13) : 12}})</span>
                   <span class="label label-danger label-alert pull-right" tooltip-trigger tooltip-placement="top"
                         tooltip="Deployment alerts">{{res.alerts}}</span>

--- a/console/src/main/scripts/plugins/metrics/html/app-server-list.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-server-list.html
@@ -105,7 +105,7 @@
           </td>
           <td>
             <a href="/hawkular-ui/app/app-details/{{res.feedId}}/{{res.id | limitTo : res.id.length-2}}/jvm/{{hkParams.timeOffset}}">
-              {{res.id | limitTo : res.id.length-2}}
+              {{res.name}}
             </a>
             <a href="/hawkular-ui/app/app-details/{{res.id}}/jvm/{{hkParams.timeOffset}}" class="pull-right">
               <span class="label label-danger label-alert" tooltip-trigger tooltip-placement="top"

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDatasourcesDetails.ts
@@ -274,9 +274,6 @@ module HawkularMetrics {
         resourceTypeId: 'JDBC Driver'
       }, (aResourceList, getResponseHeaders) => {
         this.driversList = aResourceList;
-        _.forEach(this.driversList, function (item:any) {
-          item.name = item.id.split('jdbc-driver=')[1];
-        }, this);
       });
 
     }

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesAddDialog.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesAddDialog.ts
@@ -120,9 +120,6 @@ module HawkularMetrics {
         environmentId: globalEnvironmentId, feedId: this.$routeParams.feedId,
         resourceTypeId: 'JDBC Driver'}, (aResourceList, getResponseHeaders) => {
           this.driversList = aResourceList;
-          _.forEach(this.driversList, function(item: any) {
-            item.name = item.id.split('jdbc-driver=')[1];
-          }, this);
       });
     }
 
@@ -148,7 +145,6 @@ module HawkularMetrics {
     }
 
     public addDatasource():void {
-      console.log('adding DS', this.dsData);
       this.dsData.uploading = true;
       this.HawkularOps.performAddDatasourceOperation(this.dsData.resourcePath,
         this.$rootScope.userDetails.token,

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesEditDialog.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesEditDialog.ts
@@ -62,8 +62,6 @@ module HawkularMetrics {
           }
           this.datasource.enabled = resource.value['Enabled'];
           this.datasource.jndiName = resource.value['JNDI Name'];
-          this.datasource.datasourceName =
-            this.datasource.jndiName.substr(this.datasource.jndiName.lastIndexOf('/') + 1);
           this.datasource.conn = {
             username: resource.value['Username'],
             password: resource.value['Password'],

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <version.commons.io>2.4</version.commons.io>
     <version.gnu.getopt>1.0.13</version.gnu.getopt>
     <version.org.hawkular.accounts>1.1.2.Final</version.org.hawkular.accounts>
-    <version.org.hawkular.agent>0.13.7.Final-SRC-revision-c00f616f9d0a09202d9c8ed63a68649049a43077</version.org.hawkular.agent>
+    <version.org.hawkular.agent>0.13.7.Final-SRC-revision-9b176c17b571a2176b9a3d79456186d4ffc042ae</version.org.hawkular.agent>
     <version.org.hawkular.alerts>0.7.0-SRC-revision-23092b8d9b7b526bde477b6d0ec8d4119e38a1ca</version.org.hawkular.alerts>
     <version.org.hawkular.bus>0.7.3.Final-SRC-revision-1af5bac4e32e26804b39ed6c6aa8fec66fdd2cf0</version.org.hawkular.bus>
     <version.org.hawkular.commons>0.2.3.Final</version.org.hawkular.commons>


### PR DESCRIPTION
With the renaming made in the agent, it is now possible/easier to just
use the name instead of playing around with trimming the id or the name.

Also update to latest commit of ui-services required by Update DS.