### PR TITLE
New module for common Hawkular REST api - first shot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ install:
 - mvn -s .travis.maven.settings.xml -version -B
 - df -h
 - du -sh $HOME/.m2/repository
+
+before_script:
+- ulimit -u 4096
+- ulimit -s 65535
+- ulimit -a
 script:
 - PROJECT_VERSION=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -v '\['`
 - if [[ "${PROJECT_VERSION}" =~ .*SNAPSHOT ]] && [[ "${TRAVIS_BRANCH}" = "master" ]] && [[ "${TRAVIS_PULL_REQUEST}" = "false" ]];

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,9 +36,9 @@
     <hawkular.console.context>/</hawkular.console.context>
     <hawkular.console.index.html.base.href>/</hawkular.console.index.html.base.href>
     <bower.link.package />
-    <node.version>v0.12.7</node.version>
-    <node.npm.version>2.13.2</node.npm.version>
-    <node.maven.plugin.version>0.0.23</node.maven.plugin.version>
+    <node.version>v4.2.2</node.version>
+    <node.npm.version>2.14.7</node.npm.version>
+    <node.maven.plugin.version>0.0.26</node.maven.plugin.version>
     <hawkular.checkstyle.excludes>
       release.properties,
       **/*.d.ts,

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -156,6 +156,13 @@
       <artifactId>hawkular-metrics-component</artifactId>
       <type>war</type>
     </dependency>
+    <dependency>
+      <groupId>org.hawkular</groupId>
+      <artifactId>hawkular-rest-api</artifactId>
+      <version>1.0.0.Alpha9-SNAPSHOT</version>
+      <type>war</type>
+    </dependency>
+
 
   </dependencies>
 
@@ -263,6 +270,12 @@
                 <artifactItem>
                   <groupId>org.hawkular</groupId>
                   <artifactId>hawkular-wildfly-agent-download</artifactId>
+                  <version>${project.version}</version>
+                  <type>war</type>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.hawkular</groupId>
+                  <artifactId>hawkular-rest-api</artifactId>
                   <version>${project.version}</version>
                   <type>war</type>
                 </artifactItem>

--- a/dist/src/main/resources/standalone.xsl
+++ b/dist/src/main/resources/standalone.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,6 @@
     limitations under the License.
 
 -->
-
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xalan="http://xml.apache.org/xalan"
   xmlns:ds="urn:jboss:domain:datasources:3.0" xmlns:ra="urn:jboss:domain:resource-adapters:3.0" xmlns:ejb3="urn:jboss:domain:ejb3:3.0"
   xmlns:logging="urn:jboss:domain:logging:3.0" xmlns:undertow="urn:jboss:domain:undertow:2.0" xmlns:tx="urn:jboss:domain:transactions:3.0"
@@ -105,6 +104,10 @@
         <xsl:with-param name="deployment.name" select="'hawkular-wildfly-agent-download.war'" />
         <xsl:with-param name="credential.secret" select="*[local-name()='secure-deployment']/*[local-name()='credential' and @name='secret']/text()"/>
       </xsl:call-template>
+      <xsl:call-template name="secure-deployment">
+        <xsl:with-param name="deployment.name" select="'hawkular-rest-api.war'" />
+        <xsl:with-param name="credential.secret" select="*[local-name()='secure-deployment']/*[local-name()='credential' and @name='secret']/text()"/>
+      </xsl:call-template>
     </xsl:copy>
   </xsl:template>
 
@@ -167,9 +170,19 @@
         <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.inventory.rest.requests:INFO}</xsl:text></xsl:attribute>
       </level>
     </logger>
+    <logger category="org.hawkular.inventory.ws">
+      <level>
+        <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.inventory.ws:INFO}</xsl:text></xsl:attribute>
+      </level>
+    </logger>
     <logger category="org.hawkular.metrics">
       <level>
         <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.metrics:INFO}</xsl:text></xsl:attribute>
+      </level>
+    </logger>
+    <logger category="org.hawkular.rest">
+      <level>
+        <xsl:attribute name="name"><xsl:text disable-output-escaping="yes">${hawkular.log.rest:INFO}</xsl:text></xsl:attribute>
       </level>
     </logger>
 

--- a/modules/end-to-end-test/pom.xml
+++ b/modules/end-to-end-test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,6 +34,24 @@
   <dependencies>
 
     <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.hawkular.inventory</groupId>
       <artifactId>hawkular-inventory-itest</artifactId>
       <version>${version.org.hawkular.inventory}</version>
@@ -42,6 +60,13 @@
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
       <artifactId>hawkular-inventory-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular</groupId>
+      <artifactId>hawkular-rx</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
 
@@ -68,6 +93,14 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se</artifactId>
+      <version>2.3.2.Final</version>
+      <scope>test</scope>
+    </dependency>
+
 
   </dependencies>
 
@@ -104,6 +137,7 @@
         <hawkular.log.availcreator>INFO</hawkular.log.availcreator>
         <hawkular.log.pinger>INFO</hawkular.log.pinger>
         <hawkular.log.inventory>INFO</hawkular.log.inventory>
+        <hawkular.log.inventory.rest.requests>INFO</hawkular.log.inventory.rest.requests>
         <hawkular.log.metrics>INFO</hawkular.log.metrics>
         <hawkular.log.nest>INFO</hawkular.log.nest>
         <hawkular.log.datastax.driver>INFO</hawkular.log.datastax.driver>
@@ -158,7 +192,7 @@
               <artifactId>hawkular-dist</artifactId>
               <version>${project.version}</version>
               <skip>${skipTests}</skip>
-              <startupTimeout>240</startupTimeout>
+              <startupTimeout>360</startupTimeout>
               <port>${hawkular.management.port}</port>
               <javaOpts>
                 <javaOpt>-server</javaOpt>
@@ -179,6 +213,7 @@
                 <javaOpt>-Dhawkular.log.availcreator=${hawkular.log.availcreator}</javaOpt>
                 <javaOpt>-Dhawkular.log.pinger=${hawkular.log.pinger}</javaOpt>
                 <javaOpt>-Dhawkular.log.inventory=${hawkular.log.inventory}</javaOpt>
+                <javaOpt>-Dhawkular.log.inventory.rest.requests=${hawkular.log.inventory.rest.requests}</javaOpt>
                 <javaOpt>-Dhawkular.log.metrics=${hawkular.log.metrics}</javaOpt>
                 <javaOpt>-Dhawkular.log.nest=${hawkular.log.nest}</javaOpt>
                 <javaOpt>-Dhawkular.log.datastax.driver=${hawkular.log.datastax.driver}</javaOpt>
@@ -207,6 +242,9 @@
                 <goals>
                   <goal>shutdown</goal>
                 </goals>
+                <configuration>
+                  <timeout>120</timeout>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -223,10 +261,16 @@
                 </goals>
                 <configuration>
                   <artifactItems>
+                    <!--                    <artifactItem>
+                                          <groupId>org.hawkular.inventory</groupId>
+                                          <artifactId>hawkular-inventory-itest</artifactId>
+                                          <version>${version.org.hawkular.inventory}</version>
+                                          <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                                        </artifactItem>-->
                     <artifactItem>
-                      <groupId>org.hawkular.inventory</groupId>
-                      <artifactId>hawkular-inventory-itest</artifactId>
-                      <version>${version.org.hawkular.inventory}</version>
+                      <groupId>org.hawkular</groupId>
+                      <artifactId>hawkular-end-to-end-tests</artifactId>
+                      <version>${project.version}</version>
                       <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                     </artifactItem>
                   </artifactItems>

--- a/modules/end-to-end-test/src/test/groovy/org/hawkular/integration/test/AbstractTestBase.groovy
+++ b/modules/end-to-end-test/src/test/groovy/org/hawkular/integration/test/AbstractTestBase.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@ class AbstractTestBase {
 
   protected static final String testUser = 'jdoe'
   protected static final String testPasword = 'password'
+  protected static String authHeader
 
   protected static final String baseURI
   static {
@@ -50,7 +51,8 @@ class AbstractTestBase {
      *  * The authorization method and a space i.e. "Basic " is then put before the encoded string.
      */
     String encodedCredentials = Base64.getMimeEncoder().encodeToString("$testUser:$testPasword".getBytes("utf-8"))
-    client.defaultRequestHeaders.Authorization = "Basic "+ encodedCredentials
+    authHeader = "Basic "+ encodedCredentials
+    client.defaultRequestHeaders.Authorization = authHeader
     client.defaultRequestHeaders.Accept = ContentType.JSON
   }
 

--- a/modules/end-to-end-test/src/test/groovy/org/hawkular/integration/test/HystrixCommandsITest.groovy
+++ b/modules/end-to-end-test/src/test/groovy/org/hawkular/integration/test/HystrixCommandsITest.groovy
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.integration.test
+
+import org.hawkular.rx.cdi.*
+import org.hawkular.rx.commands.hawkular.CreateUrlCommand
+import org.hawkular.rx.commands.hawkular.DeleteUrlCommand
+import org.hawkular.rx.commands.hawkular.GetUrlCommand
+import org.hawkular.rx.commands.hawkular.UpdateUrlCommand
+import org.jboss.weld.environment.se.Weld
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.Test
+import rx.Observable
+
+import javax.enterprise.inject.Any
+import javax.enterprise.inject.Instance
+import javax.inject.Inject
+import java.util.concurrent.TimeUnit
+
+import static org.junit.Assert.*
+
+class HystrixCommandsITest extends AbstractTestBase {
+
+    private di
+
+    @Inject
+    @Any
+    private Instance<GetUrlCommand> getUrlCommandInjector;
+
+    @Inject
+    @CreateCommand
+    private Instance<CreateUrlCommand> createUrlCommandInjector;
+
+    @Inject
+    @UpdateCommand
+    private Instance<UpdateUrlCommand> updateUrlCommandInjector;
+
+    @Inject
+    @Any
+    private Instance<DeleteUrlCommand> deleteUrlCommandInjector;
+
+    @Test
+    public void testComplexScenario() throws Exception {
+        this.di = new Weld()
+            .initialize()
+        def originalUrl = "www.redhat.com"
+        def newUrl = "www.hawkular.org"
+
+        def Observable<String> getTenant = Observable.<String>defer({ ->
+            def response = client.get(path: "/hawkular/inventory/tenant")
+            assertEquals(200, response.status)
+            // wait for the automagic in the inventory
+            Observable.just(response.data.id).delay(1, TimeUnit.SECONDS)
+        })
+
+        // using the flatMap for chaining the events and assert functions as testing by side-effects (it's not pure
+        // functional approach, but we need to check also the intermediate results, perhaps the .all/.filter could do
+        // the trick)
+
+        // get tenant id
+        def bigObs = getTenant.flatMap({String tenantId ->
+            // create a new url
+            di.select(CreateUrlCommand.class,
+                CreateCommandLiteral.get(),
+                Initialized.withValues(originalUrl, authHeader, tenantId))
+                .get().toObservable()
+            .flatMap({ String location ->
+                assertNotNull(location)
+                assertNotEquals(location.trim().length(), 0)
+
+                def String resId = location.substring(location.lastIndexOf("/") + 1)
+                assertNotEquals(resId.trim().length(), 0)
+                println "created url with id: $resId"
+
+                // try to retrieve it
+                getUrl(resId, tenantId)
+                    .flatMap({ url ->
+                    assertTrue(url.contains(originalUrl))
+
+                    // change the url
+                    updateUrl(resId, newUrl, tenantId)
+                })
+
+                // try to retrieve it
+                .flatMap({foo -> getUrl(resId, tenantId) })
+                .flatMap({url ->
+                    assertTrue(url.contains(newUrl))
+
+                    // delete the url
+                    deleteUrl(resId, tenantId)
+                })
+                .flatMap({foo ->
+                    // get all urls
+                    getUrl(null, tenantId)
+                })
+            })
+        })
+        .doOnError({e ->
+            println e.getMessage()
+            Assert.fail("fail: " + e.getMessage())
+        })
+        println "observable pipes initialized"
+
+        // wait for the pipe
+        def String urlJsonList = bigObs.toBlocking().first()
+
+        // check that nothing is there
+        assertEquals("[ ]", urlJsonList)
+    }
+
+    @AfterClass
+    static void cleanUp() {
+
+    }
+
+    private void assertResponseOk(int responseCode) {
+        assertTrue("Response code should be 2xx or 304 but was "+ responseCode,
+                (responseCode >= 200 && responseCode < 300) || responseCode == 304)
+    }
+
+    // todo: use this observer for all changes, if it's possible (zip combinator w/ other streams)
+    private Observable<String> getUrl(String id, String tenantId) {
+        return di.select(GetUrlCommand.class, Initialized.withValues(id, authHeader, tenantId)).get().toObservable()
+    }
+
+    private Observable<String> updateUrl(String id, String newUrl, String tenantId) {
+        return di.select(UpdateUrlCommand.class,
+            UpdateCommandLiteral.get(),
+            Initialized.withValues(id, newUrl, authHeader, tenantId))
+            .get().toObservable()
+    }
+
+    private Observable<String> deleteUrl(String id, String tenantId) {
+        return di.select(DeleteUrlCommand.class, Initialized.withValues(id, authHeader, tenantId)).get().toObservable()
+    }
+}

--- a/modules/end-to-end-test/src/test/groovy/org/hawkular/integration/test/RestApiTest.groovy
+++ b/modules/end-to-end-test/src/test/groovy/org/hawkular/integration/test/RestApiTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.integration.test
+
+import org.junit.AfterClass
+import org.junit.Assert
+import org.junit.Test
+
+import static org.junit.Assert.assertEquals
+import static org.junit.Assert.assertTrue
+
+class RestApiTest extends AbstractTestBase {
+
+    private static List<String> pathsToDelete = new ArrayList();
+
+    @Test
+    public void testScenario() throws Exception {
+        assertTrue(!false);
+    }
+
+    @Test
+    public void testScenario2() throws Exception {
+        assertTrue(!!!!!!!!!!!!!!!!!!!!!!!!!false);
+    }
+
+    @AfterClass
+    static void cleanUp() {
+
+    }
+
+    private void assertResponseOk(int responseCode) {
+        assertTrue("Response code should be 2xx or 304 but was "+ responseCode,
+                (responseCode >= 200 && responseCode < 300) || responseCode == 304)
+    }
+}

--- a/modules/end-to-end-test/src/test/groovy/org/hawkular/integration/test/Scenario1ITest.groovy
+++ b/modules/end-to-end-test/src/test/groovy/org/hawkular/integration/test/Scenario1ITest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.hawkular.integration.test
 
 import org.hawkular.inventory.api.model.Metric

--- a/modules/end-to-end-test/src/test/resources/META-INF/beans.xml
+++ b/modules/end-to-end-test/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>

--- a/modules/hawkular-api-parent/hawkular-rest-api/README.adoc
+++ b/modules/hawkular-api-parent/hawkular-rest-api/README.adoc
@@ -1,0 +1,8 @@
+= Hawkular Rest Api
+
+Base Url: /hawkular/api
+
+The API offers the following endpoints:
+
+== Add URL
+

--- a/modules/hawkular-api-parent/hawkular-rest-api/pom.xml
+++ b/modules/hawkular-api-parent/hawkular-rest-api/pom.xml
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular</groupId>
+    <artifactId>hawkular-api-parent</artifactId>
+    <version>1.0.0.Alpha9-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>hawkular-rest-api</artifactId>
+  <version>1.0.0.Alpha9-SNAPSHOT</version>
+  <packaging>war</packaging>
+
+  <name>Hawkular: REST API Web Application</name>
+  <description>Component that allows users to interface with Hawkular. One rest call to it's endpoint will probably end up with multiple requests to the individual components.</description>
+
+  <properties>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+<!--
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-cdi</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-api</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-impl-tinkerpop</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-bus</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+-->
+
+    <dependency>
+      <groupId>org.hawkular</groupId>
+      <artifactId>hawkular-rx</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-json-helper</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+    </dependency>
+
+    <!-- RX -->
+    <dependency>
+      <groupId>com.netflix.hystrix</groupId>
+      <artifactId>hystrix-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.netflix.hystrix</groupId>
+      <artifactId>hystrix-request-servlet</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+<!--
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
+-->
+    <!-- these will be provided by our RA - the MDB itself will never need ActiveMQ specific classes -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-all</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-jaas</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.accounts</groupId>
+      <artifactId>hawkular-accounts-api</artifactId>
+      <version>1.1.2.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Wildfly provided -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.transaction</groupId>
+      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- docs -->
+
+    <dependency>
+      <groupId>com.wordnik</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <version>1.5.3-M1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.wordnik</groupId>
+      <artifactId>swagger-core</artifactId>
+      <version>1.5.3-M1</version>
+    </dependency>
+
+    <!-- javadoc requires all the annotations on the classpath -->
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.interceptor</groupId>
+      <artifactId>javax.interceptor-api</artifactId>
+      <version>1.2</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <finalName>hawkular-${project.artifactId}-${project.version}</finalName>
+    <plugins>
+      <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${version.maven-war-plugin}</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+            <!-- <manifestEntries> <Build-Number>${buildNumber}</Build-Number>
+              </manifestEntries> -->
+          </archive>
+          <webResources>
+            <resource>
+              <filtering>false</filtering>
+              <directory>${basedir}/src/main/webapp</directory>
+            </resource>
+          </webResources>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>docgen</id>
+      <build>
+        <!-- Document generation from the Swagger annotations on the REST-API. -->
+        <plugins>
+          <plugin>
+            <groupId>com.github.kongchen</groupId>
+            <artifactId>swagger-maven-plugin</artifactId>
+            <configuration>
+              <apiSources>
+                <apiSource>
+                  <locations>org.hawkular.inventory.rest</locations>
+                  <apiVersion>0.1</apiVersion>
+                  <basePath>http://localhost:8080/hawkular/inventory</basePath>
+                  <outputTemplate>https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/asciidoc.mustache</outputTemplate>
+                  <swaggerDirectory>${project.build.directory}/generated/swagger-ui</swaggerDirectory>
+                  <swaggerApiReader>com.wordnik.swagger.jaxrs.reader.DefaultJaxrsApiReader</swaggerApiReader>
+                  <outputPath>${project.build.directory}/generated/rest-inventory.adoc</outputPath>
+                </apiSource>
+              </apiSources>
+            </configuration>
+            <executions>
+              <execution>
+                <phase>compile</phase>
+                <goals>
+                  <goal>generate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+<!--
+    <profile>
+      <id>dev</id>
+      <properties>
+        <wf.home>${project.build.directory}/wildfly-${version.org.wildfly}</wf.home>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-dist</artifactId>
+          <version>${version.org.wildfly}</version>
+          <type>zip</type>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>unpack-wildfly</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>unpack-dependencies</goal>
+                </goals>
+                <configuration>
+                  <includeGroupIds>org.wildfly</includeGroupIds>
+                  <includeArtifactIds>wildfly-dist</includeArtifactIds>
+                  <outputDirectory>${project.build.directory}/</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-resources-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>deploy-war</id>
+                <phase>install</phase>
+                <goals>
+                  <goal>copy-resources</goal>
+                </goals>
+                <configuration>
+                  <outputDirectory>${wf.home}/standalone/deployments/</outputDirectory>
+                  <resources>
+                    <resource>
+                      <directory>${project.build.directory}</directory>
+                      <includes>
+                        <include>*.war</include>
+                      </includes>
+                    </resource>
+                  </resources>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>install</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks>
+                    <echo>Run the server with inventory by${line.separator}${wf.home}/bin/standalone.sh${line.separator}${line.separator}</echo>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+-->
+  </profiles>
+</project>

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/HawkularRestApi.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/HawkularRestApi.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+/**
+ * JAX-RS startup "marker" class
+ *
+ * @author Heiko W. Rupp
+ */
+@ApplicationPath("/")
+public class HawkularRestApi extends Application {
+
+    public HawkularRestApi() {
+        RestApiLogger.LOGGER.apiStarting();
+//        HystrixPlugins.registerMetricsPublisher(HystrixMetricsPublisher impl).
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/PageToStreamThreadPool.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/PageToStreamThreadPool.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.3.4
+ */
+@Singleton
+public class PageToStreamThreadPool {
+
+    private static PageToStreamThreadPool instance;
+    private ExecutorService executor;
+
+    @Produces
+    @Singleton
+    public static PageToStreamThreadPool getInstance() {
+        if (instance == null) {
+            instance = new PageToStreamThreadPool();
+            instance.init();
+        }
+        return instance;
+    }
+
+    @PostConstruct
+    public void init() {
+        this.executor = Executors.newCachedThreadPool();
+    }
+
+    public void submit(Runnable work) {
+        executor.execute(work);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/PingHandler.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/PingHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import java.util.Date;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import com.wordnik.swagger.annotations.ApiOperation;
+
+/**
+ * @author Stefan Negrea
+ */
+@Path("/ping")
+public class PingHandler {
+
+    @GET
+    @Consumes({APPLICATION_JSON})
+    @Produces({APPLICATION_JSON})
+    @ApiOperation("A dummy operation returning the current date on the server.")
+    public Response ping() {
+        return Response.ok(new Date().toString()).build();
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/RequestUtil.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/RequestUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.UriInfo;
+
+import org.hawkular.inventory.api.paging.Order;
+import org.hawkular.inventory.api.paging.PageContext;
+import org.hawkular.inventory.api.paging.Pager;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.0.1
+ */
+public class RequestUtil {
+
+    private RequestUtil() {
+    }
+
+    public static Pager extractPaging(UriInfo uri) {
+        MultivaluedMap<String, String> params = uri.getQueryParameters();
+
+        String pageS = params.getFirst("page");
+        String perPageS = params.getFirst("per_page");
+        List<String> sort = params.get("sort");
+        List<String> order = params.get("order");
+
+        int page = pageS == null ? 0 : Integer.parseInt(pageS);
+        int perPage = perPageS == null ? PageContext.UNLIMITED_PAGE_SIZE : Integer.parseInt(perPageS);
+
+        List<Order> ordering = new ArrayList<>();
+
+        if (sort == null || sort.isEmpty()) {
+            ordering.add(Order.unspecified());
+        } else {
+            for (int i = 0; i < sort.size(); ++i) {
+                String field = sort.get(i);
+                Order.Direction dir = Order.Direction.ASCENDING;
+                if (order != null && i < order.size()) {
+                    dir = Order.Direction.fromShortString(order.get(i));
+                }
+
+                ordering.add(Order.by(field, dir));
+            }
+        }
+
+        return new Pager(page, perPage, ordering);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/ResponseUtil.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/ResponseUtil.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest;
+
+import static javax.ws.rs.core.Response.Status.CREATED;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Spliterator;
+import java.util.stream.StreamSupport;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+
+import org.hawkular.inventory.api.paging.Page;
+import org.hawkular.inventory.api.paging.PageContext;
+import org.hawkular.rest.json.Link;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SequenceWriter;
+
+/**
+ * @author Lukas Krejci
+ * @author Heiko W. Rupp
+ * @since 0.0.1
+ */
+final class ResponseUtil {
+
+    /**
+     * This method exists solely to concentrate usage of {@link javax.ws.rs.core.Response#created(java.net.URI)} into
+     * one place until <a href="https://issues.jboss.org/browse/RESTEASY-1162">this JIRA</a> is resolved somehow.
+     *
+     * @param info the UriInfo instance of the current request
+     * @param id   the ID of a newly created entity under the base
+     * @return the response builder with status 201 and location set to the entity with the provided id.
+     */
+    public static Response.ResponseBuilder created(UriInfo info, String id) {
+        return Response.status(CREATED).location(info.getRequestUriBuilder().segment(id).build());
+    }
+
+    /**
+     * Similar to {@link #created(UriInfo, String)} but used when more than 1 entity is created during the request.
+     * <p/>
+     * The provided list of ids is converted to URIs (by merely appending the ids using the
+     * {@link UriBuilder#segment(String...)} method) and put in the response as its entity.
+     *
+     * @param info uri info to help with converting ids to URIs
+     * @param ids  the list of ids of the entities
+     * @return the response builder with status 201 and entity set
+     */
+    public static Response.ResponseBuilder created(UriInfo info, Spliterator<String> ids) {
+        return Response.status(CREATED)
+                .entity(StreamSupport.stream(ids, false).map(
+                        (id) -> info.getRequestUriBuilder().segment(id).build()));
+    }
+
+    public static <T> Response.ResponseBuilder pagedResponse(Response.ResponseBuilder response, UriInfo uriInfo,
+                                                             ObjectMapper mapper, Page<T> page) {
+        InputStream data = null;
+        try {
+            //extract the data out of the page
+            data = pageToStream(page, mapper, () -> {
+                // the page iterator should be depleted by this time so the total size should be correctly set
+                response.type(MediaType.APPLICATION_OCTET_STREAM_TYPE);
+                createPagingHeader(response, uriInfo, page);
+            });
+        } catch (IOException e) {
+        }
+        response.entity(data);
+        return response;
+    }
+
+    public static <T> Response.ResponseBuilder pagedResponse(Response.ResponseBuilder response, UriInfo uriInfo,
+                                                             Page<T> page, Object data) {
+        response.entity(data);
+        createPagingHeader(response, uriInfo, page);
+        return response;
+    }
+
+    private static <T> InputStream pageToStream(Page<T> page, ObjectMapper mapper, Runnable callback) throws
+            IOException {
+        final PipedOutputStream outs = new PipedOutputStream();
+        final PipedInputStream ins = new PipedInputStream() {
+            @Override public void close() throws IOException {
+                outs.close();
+                super.close();
+            }
+        };
+        outs.connect(ins);
+        mapper.disable(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+
+        PageToStreamThreadPool.getInstance().submit(() -> {
+            try (Page<T> closeablePage = page;
+                 PipedOutputStream out = outs;
+                 SequenceWriter sequenceWriter = mapper.writer().writeValuesAsArray(out)) {
+                for (T element : closeablePage) {
+                    sequenceWriter.write(element);
+                    sequenceWriter.flush();
+                }
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to convert page to input stream.", e);
+            } finally {
+                callback.run();
+            }
+        });
+        return ins;
+    }
+
+    /**
+     * Create the paging headers for collections and attach them to the passed builder. Those are represented as
+     * <i>Link:</i> http headers that carry the URL for the pages and the respective relation.
+     * <br/>In addition a <i>X-Total-Count</i> header is created that contains the whole collection size.
+     *
+     * @param builder    The ResponseBuilder that receives the headers
+     * @param uriInfo    The uriInfo of the incoming request to build the urls
+     * @param resultList The collection with its paging information
+     */
+    public static void createPagingHeader(final Response.ResponseBuilder builder, final UriInfo uriInfo,
+                                          final Page<?> resultList) {
+
+        UriBuilder uriBuilder;
+
+        PageContext pc = resultList.getPageContext();
+        int page = pc.getPageNumber();
+
+        List<Link> links = new ArrayList<>();
+
+        if (pc.isLimited() && resultList.getTotalSize() > (pc.getPageNumber() + 1) * pc.getPageSize()) {
+            int nextPage = page + 1;
+            uriBuilder = uriInfo.getRequestUriBuilder(); // adds ?q, ?per_page, ?page, etc. if needed
+            uriBuilder.replaceQueryParam("page", nextPage);
+
+            links.add(new Link("next", uriBuilder.build().toString()));
+        }
+
+        if (page > 0) {
+            int prevPage = page - 1;
+            uriBuilder = uriInfo.getRequestUriBuilder(); // adds ?q, ?per_page, ?page, etc. if needed
+            uriBuilder.replaceQueryParam("page", prevPage);
+            links.add(new Link("prev", uriBuilder.build().toString()));
+        }
+
+        // A link to the last page
+        if (pc.isLimited()) {
+            long lastPage = resultList.getTotalSize() / pc.getPageSize();
+            if (resultList.getTotalSize() % pc.getPageSize() == 0) {
+                lastPage -= 1;
+            }
+
+            uriBuilder = uriInfo.getRequestUriBuilder(); // adds ?q, ?per_page, ?page, etc. if needed
+            uriBuilder.replaceQueryParam("page", lastPage);
+            links.add(new Link("last", uriBuilder.build().toString()));
+        }
+
+        // A link to the current page
+        uriBuilder = uriInfo.getRequestUriBuilder(); // adds ?q, ?per_page, ?page, etc. if needed
+
+        StringBuilder linkHeader = new StringBuilder(new Link("current", uriBuilder.build().toString())
+                .rfc5988String());
+
+        //followed by the rest of the link defined above
+        links.forEach((l) -> linkHeader.append(", ").append(l.rfc5988String()));
+
+        //add that all as a single Link header to the response
+        builder.header("Link", linkHeader.toString());
+
+        // Create a total size header
+        builder.header("X-Total-Count", resultList.getTotalSize());
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/RestApiLogger.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/RestApiLogger.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest;
+
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * Logger definitions for Jboss Logging for the rest api
+ * <p/>
+ * Code range is 2000-2999
+ *
+ * @author Heiko W. Rupp
+ */
+@MessageLogger(projectCode = "HAWKULAR")
+public interface RestApiLogger extends BasicLogger {
+
+    RestApiLogger LOGGER = Logger.getMessageLogger(RestApiLogger.class, "org.hawkular.rest");
+
+    RestApiLogger REQUESTS_LOGGER = Logger
+            .getMessageLogger(RestApiLogger.class, "org.hawkular.rest.requests");
+
+    @LogMessage(level = Logger.Level.INFO)
+    @Message(id = 5500, value = "Hawkular REST Api is starting...") void apiStarting();
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 5501, value = "Something bad has happened") void warn(@Cause Throwable t);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 5502, value = "Bus Integration initialization failed. Inventory will not notify about changes on " +
+            "the Hawkular message bus. Cause: [%s]") void busInitializationFailed(String message);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(id = 5503, value = "Security check failed on entity: [%s]") void securityCheckFailed(String entityId,
+                                                                                                  @Cause
+                                                                                                  Throwable cause);
+
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 5504, value = "Accepting:\nHTTP %s -> %s\n\nheaders:\n%s\npayload:\n%s\njavaMethod: %s\n")
+    void restCall(String method, String url, String headers, String jsonPayload, String javaMethod);
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/RestBase.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/RestBase.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest;
+
+import javax.inject.Inject;
+
+import org.hawkular.rest.security.TenantIdProducer;
+import org.jboss.resteasy.annotations.GZIP;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.0.1
+ */
+@GZIP
+public class RestBase {
+
+//    @Inject
+//    @AutoTenant
+//    protected Inventory inventory;
+
+    // using the @AllPermissive annotation the access will be always granted
+//    @Inject
+//    protected Security security;
+
+    @Inject
+    // using the @AllPermissive annotation the tenant will be always the same
+    private TenantIdProducer tenantIdProducer;
+
+//    @Inject
+//    Configuration config;
+
+//    @Inject @Our
+//    protected ObjectMapper mapper;
+
+//    protected <T> Response.ResponseBuilder pagedResponse(Response.ResponseBuilder response,
+//                                                         UriInfo uriInfo, Page<T> page) {
+//        boolean streaming = config.getFlag(RestConfiguration.Keys.STREAMING_SERIALIZATION, RestConfiguration.Keys
+//                .STREAMING_SERIALIZATION.getDefaultValue());
+//        if (streaming) {
+//            return ResponseUtil.pagedResponse(response, uriInfo, mapper, page);
+//        } else {
+//            return ResponseUtil.pagedResponse(response, uriInfo, page, page.toList());
+//        }
+//    }
+
+
+    protected String getTenantId() {
+        return tenantIdProducer.getTenantId().get();
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/RestPing.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/RestPing.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.PostConstruct;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import org.jboss.resteasy.core.Dispatcher;
+import org.jboss.resteasy.core.ResourceInvoker;
+import org.jboss.resteasy.core.ResourceMethodInvoker;
+import org.jboss.resteasy.core.ResourceMethodRegistry;
+
+/**
+ * @author Lukas Krejci
+ * @since 1.0
+ */
+@Path("/")
+@Produces(value = APPLICATION_JSON)
+@Consumes(value = APPLICATION_JSON)
+public class RestPing {
+
+    @Context
+    private Dispatcher dispatcher;
+
+    private InventoryJaxRsInfo inventoryJaxRsInfo;
+
+    @PostConstruct
+    private void init() {
+        inventoryJaxRsInfo = getEndpoints((ResourceMethodRegistry) dispatcher.getRegistry());
+        Collections.sort(inventoryJaxRsInfo.getEndpoints());
+    }
+
+    @GET
+    @Path("/")
+    public Response ping(@Context Dispatcher dispatcher) {
+        return Response.status(Response.Status.OK).entity(inventoryJaxRsInfo).build();
+    }
+
+    private InventoryJaxRsInfo getEndpoints(ResourceMethodRegistry resourceMethodRegistry) {
+        InventoryJaxRsInfo inventoryJaxRsInfo = new InventoryJaxRsInfo();
+
+        for (Map.Entry<String, List<ResourceInvoker>> entry : resourceMethodRegistry.getBounded().entrySet()) {
+            String uri = entry.getKey();
+
+            JaxRsResource jaxRsResource = new JaxRsResource(uri);
+            for (ResourceInvoker invoker : entry.getValue()) {
+                ResourceMethodInvoker method = (ResourceMethodInvoker) invoker;
+                if (method.getMethod().getDeclaringClass() == getClass()) {
+                    continue;
+                }
+
+                method.getHttpMethods().forEach(jaxRsResource::addMethod);
+            }
+
+            if (jaxRsResource.getMethods().size() > 0) {
+                inventoryJaxRsInfo.addJaxRsResources(jaxRsResource);
+            }
+        }
+
+        return inventoryJaxRsInfo;
+    }
+
+    public static class InventoryJaxRsInfo {
+        private static final String DOC_URL = "http://www.hawkular.org/";
+
+        private List<JaxRsResource> endpoints = new ArrayList<>();
+
+        public String getDocumentation() {
+            return DOC_URL;
+        }
+
+        public List<JaxRsResource> getEndpoints() {
+            return endpoints;
+        }
+
+        public boolean addJaxRsResources(JaxRsResource jaxRsResources) {
+            return this.endpoints.add(jaxRsResources);
+        }
+    }
+
+    public static class JaxRsResource implements Comparable<JaxRsResource> {
+
+        private static final Pattern NAME_PATTERN = Pattern.compile("(/[a-zA-Z]+)");
+
+        private Set<String> methods = new HashSet<>();
+        private String uri;
+
+        public JaxRsResource(String uri) {
+            this.uri = uri;
+        }
+
+        public boolean addMethod(String method) {
+            return methods.add(method);
+        }
+
+        public Set<String> getMethods() {
+            return methods;
+        }
+
+        public String getUri() {
+            return uri;
+        }
+
+        public void setUri(String uri) {
+            this.uri = uri;
+        }
+
+        private String getUriPattern(String uri) {
+            Matcher matcher = NAME_PATTERN.matcher(uri);
+            if (matcher.find()) {
+                return matcher.group();
+            }
+
+            return uri;
+        }
+
+        @Override
+        public int compareTo(JaxRsResource that) {
+            if (this == that) {
+                return 0;
+            }
+
+            String other = getUriPattern(that.getUri());
+            String current = getUriPattern(this.uri);
+
+            return current.compareTo(other);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof JaxRsResource)) return false;
+
+            JaxRsResource that = (JaxRsResource) o;
+
+            return !(uri != null ? !uri.equals(that.uri) : that.uri != null);
+
+        }
+
+        @Override
+        public int hashCode() {
+            return uri != null ? uri.hashCode() : 0;
+        }
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/entities/URL.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/entities/URL.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.api.v1.entities;
+
+import java.util.Objects;
+
+/**
+ * @author Jirka Kremser
+ */
+public class URL {
+    private final String url;
+
+    private URL() {
+        this.url = null;
+    }
+
+    public URL(String url) {
+        this.url = url;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        URL url1 = (URL) o;
+        return Objects.equals(url, url1.url);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(url);
+    }
+
+    @Override public String toString() {
+        final StringBuilder sb = new StringBuilder("URL[");
+        sb.append("url='").append(url).append('\'');
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/entities/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/entities/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.api.v1.entities;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/impl/RestURLImpl.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/impl/RestURLImpl.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.api.v1.impl;
+
+import java.net.URI;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.Response;
+
+import org.hawkular.rest.RestBase;
+import org.hawkular.rest.api.v1.entities.URL;
+import org.hawkular.rest.api.v1.interfaces.RestURL;
+import org.hawkular.rx.cdi.CreateCommand;
+import org.hawkular.rx.cdi.Initialized;
+import org.hawkular.rx.cdi.UpdateCommand;
+import org.hawkular.rx.commands.hawkular.CreateUrlCommand;
+import org.hawkular.rx.commands.hawkular.DeleteUrlCommand;
+import org.hawkular.rx.commands.hawkular.GetUrlCommand;
+import org.hawkular.rx.commands.hawkular.UpdateUrlCommand;
+import org.hawkular.rx.httpclient.HttpClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import rx.Observable;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.0.1
+ */
+public class RestURLImpl extends RestBase implements RestURL {
+
+    @Inject
+    @Default
+    private HttpClient client;
+
+    @Inject
+    private ObjectMapper mapper;
+
+    @Inject
+    @Any
+    private Instance<GetUrlCommand> getUrlCommandInjector;
+
+    @Inject
+    @CreateCommand
+    private Instance<CreateUrlCommand> createUrlCommandInjector;
+
+    @Inject
+    @UpdateCommand
+    private Instance<UpdateUrlCommand> updateUrlCommandInjector;
+
+    @Inject
+    @Any
+    private Instance<DeleteUrlCommand> deleteUrlCommandInjector;
+
+
+    @Override
+    public void getUrl(AsyncResponse asyncResponse, String id, String authToken) {
+        String tenantId = getTenantId();
+        GetUrlCommand getUrlCommand =
+                getUrlCommandInjector.select(Initialized.withValues(id, authToken, tenantId)).get();
+
+        Observable<String> observer = getUrlCommand.toObservable();
+        observer.subscribe((commandResponse) -> asyncResponse.resume(commandResponse));
+    }
+
+    @Override
+    public void getAll(AsyncResponse asyncResponse, String authToken) {
+        getUrl(asyncResponse, null, authToken);
+    }
+
+    @Override
+    public void createUrl(AsyncResponse asyncResponse, URL url, String authToken) {
+        String tenantId = getTenantId();
+
+        if (url == null || url.getUrl() == null) {
+            asyncResponse.resume("URL object is empty, pass the {url: www.example.com}");
+        }
+
+        CreateUrlCommand createUrlCommand =
+                createUrlCommandInjector.select(Initialized.withValues(url.getUrl(), authToken, tenantId)).get();
+        Observable<String> observer = createUrlCommand.toObservable();
+        observer.subscribe((commandResponse) -> {
+            URI uri = URI.create(commandResponse);
+            asyncResponse.resume(Response.created(uri).build());
+        });
+    }
+
+    @Override
+    public void updateUrl(AsyncResponse asyncResponse, String id, URL update, String authToken) {
+        String tenantId = getTenantId();
+
+        UpdateUrlCommand updateUrlCommand =
+                updateUrlCommandInjector.select(Initialized.withValues(id, update.getUrl(), authToken, tenantId)).get();
+        Observable<String> observer = updateUrlCommand.toObservable();
+        observer.subscribe((commandResponse) -> asyncResponse.resume(commandResponse));
+    }
+
+    @Override
+    public void deleteUrl(AsyncResponse asyncResponse, String id, String authToken) {
+        String tenantId = getTenantId();
+
+        DeleteUrlCommand deleteUrlCommand =
+                deleteUrlCommandInjector.select(Initialized.withValues(id, authToken, tenantId)).get();
+        Observable<String> observer = deleteUrlCommand.toObservable();
+        observer.subscribe((commandResponse) -> asyncResponse.resume(commandResponse));
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/impl/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.api.v1.impl;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/interfaces/RestURL.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/interfaces/RestURL.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.api.v1.interfaces;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+
+import org.hawkular.rest.api.v1.entities.URL;
+import org.hawkular.rest.json.ApiError;
+
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import com.wordnik.swagger.annotations.ApiParam;
+import com.wordnik.swagger.annotations.ApiResponse;
+import com.wordnik.swagger.annotations.ApiResponses;
+
+/**
+ * @author Jirka Kremser
+ */
+@Path("/urls")
+@Produces("application/hawkular.1.0.0+json")
+@Consumes(APPLICATION_JSON)
+@Api(value = "/urls", description = "Work with the URLs of the current persona")
+public interface RestURL {
+
+    @GET
+    @Path("{urlId}")
+    @ApiOperation("Retrieves the URL of the currently logged in persona")
+    @ApiResponses({
+                          @ApiResponse(code = 200, message = "OK"),
+                          @ApiResponse(code = 401, message = "Unauthorized access"),
+                          @ApiResponse(code = 404, message = "Tenant doesn't exist", response = ApiError.class),
+                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+                  }) void getUrl(@Suspended AsyncResponse asyncResponse,
+                                 @PathParam("urlId") String id,
+                                 @HeaderParam("Authorization") String authToken);
+
+    @GET
+    @ApiOperation("Retrieves all URLs of the currently logged in persona")
+    @ApiResponses({
+                          @ApiResponse(code = 200, message = "OK"),
+                          @ApiResponse(code = 401, message = "Unauthorized access"),
+                          @ApiResponse(code = 404, message = "Tenant doesn't exist", response = ApiError.class),
+                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+                  }) void getAll(@Suspended AsyncResponse asyncResponse,
+                                 @HeaderParam("Authorization") String authToken);
+
+    @POST
+    @Path("/")
+    @ApiOperation("Creates the URL of the currently logged in persona")
+    @ApiResponses({
+                          @ApiResponse(code = 200, message = "OK"),
+                          @ApiResponse(code = 401, message = "Unauthorized access"),
+                          @ApiResponse(code = 404, message = "Tenant doesn't exist", response = ApiError.class),
+                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+                  }) void createUrl(@Suspended AsyncResponse asyncResponse,
+                                    @ApiParam(required = true) URL url,
+                                    @HeaderParam("Authorization") String authToken);
+
+    @PUT
+    @Path("/")
+    @ApiOperation("Updates properties of the URL")
+    @ApiResponses({
+                          @ApiResponse(code = 204, message = "OK"),
+                          @ApiResponse(code = 400, message = "Invalid input data", response = ApiError.class),
+                          @ApiResponse(code = 401, message = "Unauthorized access"),
+                          @ApiResponse(code = 404, message = "Tenant doesn't exist", response = ApiError.class),
+                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+                  }) void updateUrl(@Suspended AsyncResponse asyncResponse,
+                                    @PathParam("urlId") String id,
+                                    @ApiParam(required = true) URL url,
+                                    @HeaderParam("Authorization") String authToken);
+
+    @DELETE
+    @Path("/")
+    @ApiOperation("Deletes the URL and all its data")
+    @ApiResponses({
+                          @ApiResponse(code = 204, message = "OK"),
+                          @ApiResponse(code = 401, message = "Unauthorized access"),
+                          @ApiResponse(code = 404, message = "Tenant doesn't exist", response = ApiError.class),
+                          @ApiResponse(code = 500, message = "Server error", response = ApiError.class)
+                  }) void deleteUrl(@Suspended AsyncResponse asyncResponse,
+                                    @PathParam("urlId") String id,
+                                    @HeaderParam("Authorization") String authToken);
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/interfaces/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/interfaces/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.api.v1.interfaces;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/api/v1/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.api.v1;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/cdi/ConfigurationProducer.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/cdi/ConfigurationProducer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.cdi;
+
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.hawkular.inventory.api.Configuration;
+
+/**
+ * This class produces the {@link Configuration} instance.
+ *
+ * @author Jirka Kremser
+ * @since 0.4.1
+ */
+@Singleton
+public final class ConfigurationProducer {
+
+    @Produces
+    @Default
+    @Singleton
+    public Configuration getConfiguration() {
+        return null;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/cdi/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/cdi/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.cdi;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/BadRequestExceptionMapper.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/BadRequestExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.BadRequestException;
+
+/**
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Bad Request (400) is encountered.
+ * <p/>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, a {@link
+ * javax.ws.rs.ext.ParamConverter} throws an {@link java.lang.IllegalArgumentException}.
+ *
+ * @author Thomas Segismont
+ */
+@Provider
+public class BadRequestExceptionMapper implements ExceptionMapper<BadRequestException> {
+
+    @Override
+    public Response toResponse(BadRequestException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/DefaultOptionsMethodExceptionMapper.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/DefaultOptionsMethodExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.DefaultOptionsMethodException;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class DefaultOptionsMethodExceptionMapper implements ExceptionMapper<DefaultOptionsMethodException> {
+
+    @Override
+    public Response toResponse(DefaultOptionsMethodException exception) {
+        return Response.ok().build();
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/ExceptionMapperUtils.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/ExceptionMapperUtils.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.hawkular.inventory.api.EntityAlreadyExistsException;
+import org.hawkular.inventory.api.EntityNotFoundException;
+import org.hawkular.inventory.api.RelationAlreadyExistsException;
+import org.hawkular.inventory.api.RelationNotFoundException;
+import org.hawkular.inventory.api.filters.Filter;
+import org.hawkular.rest.RestApiLogger;
+import org.hawkular.rest.json.ApiError;
+import org.jboss.logging.Logger;
+
+import com.google.common.base.Throwables;
+
+/**
+ * @author Lukas Krejci
+ * @author Jeeva Kandasamy
+ * @since 0.1.0
+ */
+public class ExceptionMapperUtils {
+    private ExceptionMapperUtils() {
+
+    }
+
+    public static Response buildResponse(Throwable exception, Response.Status status) {
+        return buildResponse(new ApiError(Throwables.getRootCause(exception).getMessage()), exception, status);
+    }
+
+    public static Response buildResponse(ApiError error, Throwable exception, Response.Status status) {
+        return buildResponse(Logger.Level.WARN, error, exception, status);
+    }
+
+    public static Response buildResponse(Logger.Level lvl, ApiError error, Throwable exception,
+                                         Response.Status status) {
+        RestApiLogger.LOGGER.log(lvl, "RestEasy exception, ", exception);
+        return Response.status(status)
+                .entity(error)
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .build();
+    }
+
+    public static class EntityTypeAndPath {
+        private final String entityType;
+        private final Filter[][] paths;
+
+        public static EntityTypeAndPath fromException(EntityNotFoundException e) {
+            return new EntityTypeAndPath(e.getEntityType().getSimpleName(), e.getFilters());
+        }
+
+        public EntityTypeAndPath(String entityType, Filter[][] paths) {
+            this.entityType = entityType;
+            this.paths = paths;
+        }
+
+        public String getEntityType() {
+            return entityType;
+        }
+
+        public Filter[][] getPath() {
+            return paths;
+        }
+    }
+
+    public static class EntityIdAndPath {
+        private final String entityId;
+        private final Filter[][] paths;
+
+        public static EntityIdAndPath fromException(EntityAlreadyExistsException e) {
+            return new EntityIdAndPath(e.getEntityId(), e.getPaths());
+        }
+
+        public EntityIdAndPath(String entityId, Filter[][] paths) {
+            this.entityId = entityId;
+            this.paths = paths;
+        }
+
+        public String getEntityId() {
+            return entityId;
+        }
+
+        public Filter[][] getPaths() {
+            return paths;
+        }
+    }
+
+    public static class RelationshipNameAndPath {
+        private final String relationshipNameOrId;
+        private final Filter[][] paths;
+
+        public static RelationshipNameAndPath fromException(RelationNotFoundException e) {
+            return new RelationshipNameAndPath(e.getNameOrId(), e.getFilters());
+        }
+
+        public static RelationshipNameAndPath fromException(RelationAlreadyExistsException e) {
+            return new RelationshipNameAndPath(e.getRelationName(), e.getPath());
+        }
+
+        public RelationshipNameAndPath(String relationshipNameOrId, Filter[][] paths) {
+            this.relationshipNameOrId = relationshipNameOrId;
+            this.paths = paths;
+        }
+
+        public String getRelationshipNameOrId() {
+            return relationshipNameOrId;
+        }
+
+        public Filter[][] getPaths() {
+            return paths;
+        }
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/FallbackExceptionMapper.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/FallbackExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class FallbackExceptionMapper implements ExceptionMapper<Exception> {
+
+    @Override
+    public Response toResponse(Exception exception) {
+        return ExceptionMapperUtils.buildResponse(exception, INTERNAL_SERVER_ERROR);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/IllegalArgumentExceptionMapper.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/IllegalArgumentExceptionMapper.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+public class IllegalArgumentExceptionMapper implements ExceptionMapper<IllegalArgumentException> {
+
+    @Override
+    public Response toResponse(IllegalArgumentException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, BAD_REQUEST);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/NotAcceptableExceptionMapper.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/NotAcceptableExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import javax.ws.rs.NotAcceptableException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Not Acceptable (406) is encountered.
+ * <p/>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, receive a
+ * HTTP GET request with unsupported media type.
+ *
+ * @author Jeeva Kandasamy
+ */
+@Provider
+public class NotAcceptableExceptionMapper implements ExceptionMapper<NotAcceptableException> {
+
+    @Override
+    public Response toResponse(NotAcceptableException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.NOT_ACCEPTABLE);
+    }
+
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/NotAllowedExceptionMapper.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/NotAllowedExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import javax.ws.rs.NotAllowedException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Method Not Allowed (405) is encountered.
+ * <p/>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, receive
+ * a HTTP POST request for a resource which does not support for HTTP POST method.
+ *
+ * @author Jeeva Kandasamy
+ */
+@Provider
+public class NotAllowedExceptionMapper implements ExceptionMapper<NotAllowedException> {
+
+    @Override
+    public Response toResponse(NotAllowedException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.METHOD_NOT_ALLOWED);
+    }
+
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/NotSupportedExceptionMapper.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/NotSupportedExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import javax.ws.rs.NotSupportedException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * Exception mapper for any exception thrown by RESTEasy when HTTP Unsupported Media Type (415) is encountered.
+ * <p/>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, receive a
+ * HTTP POST request with unsupported media type.
+ *
+ * @author Jeeva Kandasamy
+ */
+@Provider
+public class NotSupportedExceptionMapper implements ExceptionMapper<NotSupportedException> {
+
+    @Override
+    public Response toResponse(NotSupportedException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.UNSUPPORTED_MEDIA_TYPE);
+    }
+
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/ReaderExceptionMapper.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/ReaderExceptionMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.jboss.resteasy.spi.ReaderException;
+
+/**
+ * Exception mapper for any exception thrown by a body reader chain.
+ * <p/>
+ * This mapper let us reply to the user with a pre-determined message format if, for example, a JSON entity cannot be
+ * parsed.
+ *
+ * @author Thomas Segismont
+ */
+@Provider
+public class ReaderExceptionMapper implements ExceptionMapper<ReaderException> {
+
+    @Override
+    public Response toResponse(ReaderException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/ValidationExceptionMapper.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/ValidationExceptionMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.exception.mappers;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.hawkular.inventory.api.ValidationException;
+
+/**
+ * Exception mapper for {@link ValidationException}s thrown by Inventory.
+ *
+ * @author <a href="https://github.com/ppalaga">Peter Palaga</a>
+ */
+@Provider
+public class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
+
+    @Override
+    public Response toResponse(ValidationException exception) {
+        return ExceptionMapperUtils.buildResponse(exception, Response.Status.BAD_REQUEST);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/exception/mappers/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.exception.mappers;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/features/CompressionFeature.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/features/CompressionFeature.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.features;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.2.0
+ */
+
+import static java.util.Arrays.asList;
+
+import java.util.HashSet;
+
+import javax.ws.rs.ConstrainedTo;
+import javax.ws.rs.RuntimeType;
+import javax.ws.rs.container.DynamicFeature;
+import javax.ws.rs.container.ResourceInfo;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.ext.Provider;
+import javax.ws.rs.ext.WriterInterceptor;
+
+import org.jboss.resteasy.plugins.interceptors.encoding.ServerContentEncodingAnnotationFilter;
+
+@Provider
+@ConstrainedTo(RuntimeType.SERVER)
+public class CompressionFeature implements DynamicFeature {
+
+    private WriterInterceptor compressionFilter =
+            new ServerContentEncodingAnnotationFilter(new HashSet<>(asList("gzip")));
+
+    @Override
+    public void configure(ResourceInfo resourceInfo, FeatureContext context) {
+        context.register(compressionFilter);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/features/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/features/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.features;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/interceptors/LoggingInterceptor.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/interceptors/LoggingInterceptor.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.interceptors;
+
+import static org.hawkular.rest.RestApiLogger.REQUESTS_LOGGER;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.commons.io.IOUtils;
+import org.hawkular.rx.cdi.JacksonConfig;
+import org.jboss.resteasy.annotations.interception.ServerInterceptor;
+import org.jboss.resteasy.core.interception.PostMatchContainerRequestContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.2.0
+ */
+
+@Provider
+@ServerInterceptor
+public class LoggingInterceptor implements ContainerRequestFilter {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    static {
+        JacksonConfig.initializeObjectMapper(MAPPER);
+    }
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+        if (REQUESTS_LOGGER.isDebugEnabled()) {
+            final String method = containerRequestContext.getMethod();
+            final String url = containerRequestContext.getUriInfo().getRequestUri().toString();
+            final StringBuilder headersStr = new StringBuilder();
+            MultivaluedMap<String, String> headers = containerRequestContext.getHeaders();
+            for (MultivaluedMap.Entry<String, List<String>> header : headers.entrySet()) {
+                headersStr.append(header.getKey()).append(": ").append(header.getValue()).append('\n');
+            }
+
+            String json = null;
+            if ("POST".equals(method) || "PUT".equals(method)) {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                IOUtils.copy(containerRequestContext.getEntityStream(), baos);
+                byte[] jsonBytes = baos.toByteArray();
+                json = new String(jsonBytes, "UTF-8");
+                Object jsonObject = MAPPER.readValue(json, Object.class);
+                json = MAPPER.writeValueAsString(jsonObject);
+                containerRequestContext.setEntityStream(new ByteArrayInputStream(jsonBytes));
+            }
+            PostMatchContainerRequestContext pmContext = (PostMatchContainerRequestContext) containerRequestContext;
+            // this should be safe, because if some calling non-existent api the javax.ws.rs.NotFoundException should
+            // be already thrown and this interceptor isn't triggered
+            Method javaMethod = pmContext.getResourceMethod().getMethod();
+            REQUESTS_LOGGER.restCall(method, url, headersStr.toString(), json == null ? "empty" : json,
+                    javaMethod.toGenericString());
+        }
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/interceptors/OptionsRequestFilter.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/interceptors/OptionsRequestFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.interceptors;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * @author Jirka Kremser
+ */
+
+@Provider
+@PreMatching
+public class OptionsRequestFilter implements ContainerRequestFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext) throws IOException {
+        //NOT a CORS request
+        if (requestContext.getHeaderString("Origin") == null) {
+            return;
+        }
+
+        //It is a CORS pre-flight request, there is no route for it, just return 200
+        if (requestContext.getRequest().getMethod().equalsIgnoreCase("OPTIONS")) {
+            requestContext.abortWith(Response.status(Response.Status.OK).build());
+        }
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/interceptors/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/interceptors/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.interceptors;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/ApiError.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/ApiError.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.json;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+/**
+ * Return information what failed in the REST-call.
+ *
+ * @author Michael Burman
+ */
+@XmlRootElement
+@ApiModel(description = "If REST-call returns other than success, detailed error is returned.")
+public class ApiError {
+    private final String errorMsg;
+    private final Object details;
+
+    @JsonCreator
+    public ApiError(@JsonProperty("errorMsg") String errorMsg) {
+        this(errorMsg, null);
+    }
+
+    @JsonCreator
+    public ApiError(@JsonProperty("errorMsg") String errorMsg, @JsonProperty("details") Object details) {
+        this.errorMsg = errorMsg;
+        this.details = details;
+    }
+
+    @ApiModelProperty("Detailed error message of what happened")
+    public String getErrorMsg() {
+        return errorMsg;
+    }
+
+    @ApiModelProperty("Optional details about the error beyond what's provided in the error message.")
+    public Object getDetails() {
+        return details;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/Link.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/Link.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.json;
+
+import javax.ws.rs.Produces;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+/**
+ * A link between two resources
+ *
+ * @author Heiko W. Rupp
+ * @since 0.0.1
+ */
+@ApiModel("Link between two resources")
+@XmlRootElement
+@JsonSerialize(using = LinkSerializer.class)
+@JsonDeserialize(using = LinkDeserializer.class)
+@Produces({"application/json", "application/xml"})
+public class Link {
+
+    private String rel;
+    private String href;
+
+    public Link() {
+    }
+
+    public Link(String rel, String href) {
+        this.rel = rel;
+        this.href = href;
+    }
+
+
+    @ApiModelProperty("Name of the relation")
+    @XmlAttribute
+    public String getRel() {
+        return rel;
+    }
+
+    public void setRel(String rel) {
+        this.rel = rel;
+    }
+
+    @ApiModelProperty("Target of the relation")
+    @XmlAttribute
+    public String getHref() {
+        return href;
+    }
+
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    @Override
+    public String toString() {
+        return
+                href + "; " +
+                        "rel='" + rel + '\'';
+    }
+
+    /**
+     * Return the link in the format of RFC 5988 Web Linking.
+     * <p/>
+     * See <a href="http://tools.ietf.org/html/rfc5988#page-7">RFC 5988 Web Linking</a>
+     *
+     * @return String that contains the link with href and rel
+     */
+    public String rfc5988String() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("<")
+                .append(href)
+                .append(">; rel=\"")
+                .append(rel)
+                .append("\"");
+        return builder.toString();
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/LinkDeserializer.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/LinkDeserializer.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.json;
+
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+/**
+ * Deserialize incoming json Links into Link objects
+ * Our input is like this:
+ * <p/>
+ * <pre>
+ * {
+ * "operationDefinitions": {
+ * "href": "http://localhost:7080/rest/operation/definitions?resourceId=10584"
+ * }
+ * }
+ * </pre>
+ *
+ * @author Heiko W. Rupp
+ * @see LinkSerializer
+ * @since 0.0.1
+ */
+public class LinkDeserializer extends JsonDeserializer<Link> {
+
+    Pattern textPattern = Pattern.compile("\\S+"); // Non whitespace; could possibly be narrowed
+
+    @Override
+    public Link deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+
+        String tmp = jp.getText(); // {
+        validate(jp, tmp, "{");
+        jp.nextToken(); // skip over { to the rel
+        String rel = jp.getText();
+        validateText(jp, rel);
+        jp.nextToken(); // skip over  {
+        tmp = jp.getText();
+        validate(jp, tmp, "{");
+        jp.nextToken(); // skip over "href"
+        tmp = jp.getText();
+        validate(jp, tmp, "href");
+        jp.nextToken(); // skip to "http:// ... "
+        String href = jp.getText();
+        validateText(jp, href);
+        jp.nextToken(); // skip }
+        tmp = jp.getText();
+        validate(jp, tmp, "}");
+        jp.nextToken(); // skip }
+        tmp = jp.getText();
+        validate(jp, tmp, "}");
+
+        Link link = new Link(rel, href);
+
+        return link;
+    }
+
+    private void validateText(JsonParser jsonParser, String input) throws JsonProcessingException {
+        Matcher m = textPattern.matcher(input);
+        if (!m.matches()) {
+            throw new JsonParseException("Unexpected token: " + input, jsonParser.getTokenLocation());
+        }
+    }
+
+    private void validate(JsonParser jsonParser, String input, String expected) throws JsonProcessingException {
+        if (!input.equals(expected)) {
+            throw new JsonParseException("Unexpected token: " + input, jsonParser.getTokenLocation());
+        }
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/LinkSerializer.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/LinkSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Special serializer for Link objects that does not map the classical {rel:abc, href:xyz} scheme,
+ * but which puts the rel name "at the outside" like  { abc : { href : xyz }} to make it easier for
+ * clients to access the link.
+ * See also https://bugzilla.redhat.com/show_bug.cgi?id=845244
+ *
+ * @author Heiko W. Rupp
+ * @see LinkDeserializer
+ * @since 0.0.1
+ */
+public class LinkSerializer extends JsonSerializer<Link> {
+
+    @Override
+    public void serialize(Link link, JsonGenerator jsonGenerator,
+                          SerializerProvider serializerProvider) throws IOException {
+
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeFieldName(link.getRel());
+
+        jsonGenerator.writeStartObject();
+        jsonGenerator.writeFieldName("href");
+        jsonGenerator.writeString(link.getHref());
+        jsonGenerator.writeEndObject();
+
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/RelationshipJacksonDeserializer.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/RelationshipJacksonDeserializer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.json;
+
+import static org.hawkular.rest.json.RelationshipJacksonSerializer.FIELD_ID;
+import static org.hawkular.rest.json.RelationshipJacksonSerializer.FIELD_NAME;
+import static org.hawkular.rest.json.RelationshipJacksonSerializer.FIELD_PROPERTIES;
+import static org.hawkular.rest.json.RelationshipJacksonSerializer.FIELD_SOURCE;
+import static org.hawkular.rest.json.RelationshipJacksonSerializer.FIELD_TARGET;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.hawkular.inventory.api.model.CanonicalPath;
+import org.hawkular.inventory.api.model.Relationship;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * This class should contain the inverse function for
+ * {@link RelationshipJacksonSerializer#serialize(org.hawkular.inventory.api.model.Relationship,
+ * com.fasterxml.jackson.core.JsonGenerator, com.fasterxml.jackson.databind.SerializerProvider)}
+ *
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+public class RelationshipJacksonDeserializer extends JsonDeserializer<Relationship> {
+
+    @Override
+    public Relationship deserialize(JsonParser jp, DeserializationContext deserializationContext) throws
+            IOException {
+        JsonNode node = jp.getCodec().readTree(jp);
+        String id = node.get(FIELD_ID) != null ? node.get(FIELD_ID).asText() : null;
+
+        // other fields are not compulsory, e.g. when deleting the relationship {id: foo} is just fine
+        String name = "";
+        if (node.get(FIELD_NAME) != null) {
+            name = node.get(FIELD_NAME).asText();
+        }
+        CanonicalPath source = null, target = null;
+        if (node.get(FIELD_SOURCE) != null && !node.get(FIELD_SOURCE).asText().isEmpty()) {
+            String sourcePath = node.get(FIELD_SOURCE).asText();
+            source = CanonicalPath.fromString(sourcePath);
+        }
+        if (node.get(FIELD_TARGET) != null && !node.get(FIELD_TARGET).asText().isEmpty()) {
+            String targetPath = node.get(FIELD_TARGET).asText();
+            target = CanonicalPath.fromString(targetPath);
+        }
+
+        JsonNode properties = node.get(FIELD_PROPERTIES);
+        Map<String, Object> relProperties = null;
+        if (properties != null) {
+            try {
+                Stream<Map.Entry<String, JsonNode>> stream = StreamSupport
+                        .stream(Spliterators.spliteratorUnknownSize(properties.fields(), Spliterator.ORDERED), false);
+
+                relProperties = stream
+                        .collect(Collectors.toMap(Map.Entry::getKey,
+                                ((Function<Map.Entry<String, JsonNode>, JsonNode>) Map.Entry::getValue)
+                                        .andThen(x -> (Object) x.asText())));
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Error during relationship deserialization," +
+                        " unable to recognize properties: " + properties);
+            }
+        }
+
+        return new Relationship(id, name, source, target, relProperties);
+    }
+
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/RelationshipJacksonSerializer.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/RelationshipJacksonSerializer.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.json;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.hawkular.inventory.api.model.Relationship;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+public class RelationshipJacksonSerializer extends JsonSerializer<Relationship> {
+    public static final String FIELD_ID = "id";
+    public static final String FIELD_NAME = "name";
+    public static final String FIELD_SOURCE = "source";
+    public static final String FIELD_TARGET = "target";
+    public static final String FIELD_PROPERTIES = "properties";
+
+    /**
+     * <pre>compact:
+     * {
+     *   "id": "1337",
+     *   "source": "/tenants/28026b36-8fe4-4332-84c8-524e173a68bf",
+     *   "name": "contains",
+     *   "target": "28026b36-8fe4-4332-84c8-524e173a68bf/environments/test"
+     * }</pre>
+     * <p/>
+     * <pre>embedded:
+     * {
+     *   "@context": "http://hawkular.org/inventory/0.1.0/relationship.jsonld",
+     *   "id": "1337",
+     *   "name": "contains",
+     *   "source": {
+     *      id: "/tenants/28026b36-8fe4-4332-84c8-524e173a68bf",
+     *      shortId: "28026b36-8fe4-4332-84c8-524e173a68bf",
+     *      type: "Tenant"
+     *   },
+     *   "target": {
+     *      id: "28026b36-8fe4-4332-84c8-524e173a68bf/environments/test",
+     *      shortId: "test",
+     *      type: "Environment"
+     *   }
+     * }</pre>
+     */
+    @Override
+    public void serialize(Relationship relationship, JsonGenerator jg, SerializerProvider
+            serializerProvider) throws IOException {
+        jg.writeStartObject();
+
+        jg.writeFieldName(FIELD_ID);
+        jg.writeString(relationship.getId());
+
+        jg.writeFieldName(FIELD_NAME);
+        jg.writeString(relationship.getName());
+
+        jg.writeFieldName(FIELD_SOURCE);
+        jg.writeString(relationship.getSource().toString());
+
+        jg.writeFieldName(FIELD_TARGET);
+        jg.writeString(relationship.getTarget().toString());
+
+        if (relationship.getProperties() != null && !relationship.getProperties().isEmpty()) {
+            jg.writeFieldName(FIELD_PROPERTIES);
+            jg.writeStartObject();
+            for (Map.Entry<String, Object> property : relationship.getProperties().entrySet()) {
+                jg.writeFieldName(property.getKey());
+                jg.writeObject(property.getValue());
+            }
+            jg.writeEndObject();
+        }
+
+        jg.writeEndObject();
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/json/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.json;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/DefaultTenantIdProducer.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/DefaultTenantIdProducer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.security;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+import org.hawkular.accounts.api.model.Persona;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.0.1
+ */
+@RequestScoped
+@Default
+public class DefaultTenantIdProducer implements TenantIdProducer {
+
+    @Inject Instance<Persona> personaInstance;
+
+    @Override
+    @Produces
+    @Default
+    public TenantId getTenantId() {
+        return new TenantId(personaInstance.get().getId());
+    }
+}
+

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/InventorySecurity.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/InventorySecurity.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.security;
+
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.inject.Default;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+import org.hawkular.accounts.api.OperationService;
+import org.hawkular.accounts.api.PermissionChecker;
+import org.hawkular.accounts.api.model.Operation;
+import org.hawkular.rest.RestApiLogger;
+
+/**
+ * CDI bean that provides inventory-focused abstractions over Hawkular accounts.
+ * It defines all the operations available in inventory and implements permission checking methods.
+ *
+ * @author Lukas Krejci
+ * @since 0.0.2
+ */
+@Singleton
+@Default
+public class InventorySecurity implements Security {
+
+    private final Map<Class<?>, Map<OperationType, Operation>> operationsByType =
+            new HashMap<>();
+
+    @Inject
+    private PermissionChecker permissions;
+
+    @Inject
+    private OperationService operations;
+
+
+    private boolean inventoryInitialized = false;
+
+    @javax.annotation.Resource
+    private UserTransaction transaction;
+
+    public boolean canCreate(String entityType) {
+        return true;
+    }
+
+    public boolean canUpdate(String path) {
+        return true;
+    }
+
+    public boolean canDelete(String path) {
+        return true;
+    }
+
+    public boolean canAssociateFrom(String path) {
+        return true;
+    }
+
+    public boolean canCopyEnvironment(String path) {
+        return true;
+    }
+
+    private Operation create(Class<?> entityType) {
+        return getOperation(entityType, OperationType.CREATE);
+    }
+
+    private Operation update(Class<?> entityType) {
+        return getOperation(entityType, OperationType.UPDATE);
+    }
+
+    private Operation delete(Class<?> entityType) {
+        return getOperation(entityType, OperationType.DELETE);
+    }
+
+    private Operation getOperation(Class<?> cls, OperationType operationType) {
+        Map<OperationType, Operation> ops = operationsByType.get(cls);
+        if (ops == null) {
+            throw new IllegalArgumentException("There is no " + operationType + " operation for elements of type " +
+                    cls);
+        }
+
+        return ops.get(operationType);
+    }
+
+    private boolean safePermissionCheck(String path, Operation operation) {
+        return true;
+    }
+
+    private boolean safePermissionCheck(Class<?> entityType, String entityId, Operation operation, String stableId) {
+        try {
+            RestApiLogger.LOGGER.debugf("Permission check for operation '%s' for entity with stable ID '%s'",
+                    operation.getName(), stableId);
+            return permissions.isAllowedTo(operation, stableId);
+        } catch (Exception e) {
+            RestApiLogger.LOGGER.securityCheckFailed(stableId, e);
+            return false;
+        }
+    }
+
+    //    @PostConstruct
+    public void initOperationsMap() {
+
+        // Monitor – a read-only role. Cannot modify any resource.
+        // Operator – Monitor permissions, plus can modify runtime state, but cannot modify anything that ends up in the
+        //            persistent configuration. Could, for example, restart a server.
+        // Maintainer – Operator permissions, plus can modify the persistent configuration.
+        // Deployer – like a Maintainer, but with permission to modify persistent configuration constrained to resources
+        //            that are considered to be "application resources". A deployment is an application resource. The
+        //            messaging server is not. Items like datasources and JMS destinations are not considered to be
+        //            application resources by default, but this is configurable.
+        //
+        // Three roles are granted permissions for security sensitive items:
+        //
+        // SuperUser – has all permissions. Equivalent to a JBoss AS 7 administrator.
+        // Administrator – has all permissions except cannot read or write resources related to the administrative audit
+        //                 logging system.
+        // Auditor – can read anything. Can only modify the resources related to the administrative audit logging
+        //           system.
+
+        if (!SecurityIntegration.isDummy()) {
+            try {
+                transaction.begin();
+                operations.setup("update-tenant").add("SuperUser").persist();
+                operations.setup("delete-tenant").add("SuperUser").persist();
+
+                operations.setup("create-environment").add("Administrator").persist();
+                operations.setup("update-environment").add("Administrator").persist();
+                operations.setup("delete-environment").add("Administrator").persist();
+                operations.setup("copy-environment").add("Administrator").persist();
+
+                operations.setup("create-resourceType").add("Administrator").persist();
+                operations.setup("update-resourceType").add("Administrator").persist();
+                operations.setup("delete-resourceType").add("Administrator").persist();
+
+                operations.setup("create-metricType").add("Administrator").persist();
+                operations.setup("update-metricType").add("Administrator").persist();
+                operations.setup("delete-metricType").add("Administrator").persist();
+
+                operations.setup("create-operationType").add("Administrator").persist();
+                operations.setup("update-operationType").add("Administrator").persist();
+                operations.setup("delete-operationType").add("Administrator").persist();
+
+                operations.setup("create-feed").add("Administrator").persist();
+                operations.setup("update-feed").add("Administrator").persist();
+                operations.setup("delete-feed").add("Administrator").persist();
+
+                operations.setup("create-resource").add("Maintainer").persist();
+                operations.setup("update-resource").add("Maintainer").persist();
+                operations.setup("delete-resource").add("Maintainer").persist();
+
+                operations.setup("create-metric").add("Maintainer").persist();
+                operations.setup("update-metric").add("Maintainer").persist();
+                operations.setup("delete-metric").add("Maintainer").persist();
+
+                operations.setup("associate").add("Operator").persist();
+
+                transaction.commit();
+            } catch (Throwable t) {
+                try {
+                    transaction.rollback();
+                } catch (SystemException e) {
+                    throw new IllegalStateException("Unable to do the rollback: " + e.getMessage(), t);
+                }
+                throw new IllegalStateException(t);
+            }
+
+            Operation updateTenantOperation = operations.getByName("update-tenant");
+            Operation deleteTenantOperation = operations.getByName("delete-tenant");
+
+            Operation createEnvironmentOperation = operations.getByName("create-environment");
+            Operation updateEnvironmentOperation = operations.getByName("update-environment");
+            Operation deleteEnvironmentOperation = operations.getByName("delete-environment");
+            Operation copyEnvironmentOperation = operations.getByName("copy-environment");
+
+            Operation createResourceTypeOperation = operations.getByName("create-resourceType");
+            Operation updateResourceTypeOperation = operations.getByName("update-resourceType");
+            Operation deleteResourceTypeOperation = operations.getByName("delete-resourceType");
+
+            Operation createMetricTypeOperation = operations.getByName("create-metricType");
+            Operation updateMetricTypeOperation = operations.getByName("update-metricType");
+            Operation deleteMetricTypeOperation = operations.getByName("delete-metricType");
+
+            Operation createOperationTypeOperation = operations.getByName("create-operationType");
+            Operation updateOperationTypeOperation = operations.getByName("update-operationType");
+            Operation deleteOperationTypeOperation = operations.getByName("delete-operationType");
+
+            Operation createFeedOperation = operations.getByName("create-feed");
+            Operation updateFeedOperation = operations.getByName("update-feed");
+            Operation deleteFeedOperation = operations.getByName("delete-feed");
+
+            Operation createResourceOperation = operations.getByName("create-resource");
+            Operation updateResourceOperation = operations.getByName("update-resource");
+            Operation deleteResourceOperation = operations.getByName("delete-resource");
+
+            Operation createMetricOperation = operations.getByName("create-metric");
+            Operation updateMetricOperation = operations.getByName("update-metric");
+            Operation deleteMetricOperation = operations.getByName("delete-metric");
+
+            Operation associate = operations.getByName("associate");
+
+            operationsByType.put(String.class, new EnumMap<OperationType, Operation>(OperationType.class) {{
+                put(OperationType.UPDATE, updateTenantOperation);
+                put(OperationType.DELETE, deleteTenantOperation);
+            }});
+
+            operationsByType.put(String.class, new EnumMap<OperationType, Operation>(OperationType.class) {{
+                put(OperationType.CREATE, createEnvironmentOperation);
+                put(OperationType.UPDATE, updateEnvironmentOperation);
+                put(OperationType.DELETE, deleteEnvironmentOperation);
+                put(OperationType.COPY, copyEnvironmentOperation);
+            }});
+
+            operationsByType.put(String.class, new EnumMap<OperationType, Operation>(OperationType.class) {{
+                put(OperationType.CREATE, createResourceTypeOperation);
+                put(OperationType.UPDATE, updateResourceTypeOperation);
+                put(OperationType.DELETE, deleteResourceTypeOperation);
+            }});
+
+            operationsByType.put(String.class, new EnumMap<OperationType, Operation>(OperationType.class) {{
+                put(OperationType.CREATE, createMetricTypeOperation);
+                put(OperationType.UPDATE, updateMetricTypeOperation);
+                put(OperationType.DELETE, deleteMetricTypeOperation);
+            }});
+
+            operationsByType.put(String.class, new EnumMap<OperationType, Operation>(OperationType.class) {{
+                put(OperationType.CREATE, createFeedOperation);
+                put(OperationType.UPDATE, updateFeedOperation);
+                put(OperationType.DELETE, deleteFeedOperation);
+            }});
+
+            operationsByType.put(String.class, new EnumMap<OperationType, Operation>(OperationType.class) {{
+                put(OperationType.CREATE, createResourceOperation);
+                put(OperationType.UPDATE, updateResourceOperation);
+                put(OperationType.DELETE, deleteResourceOperation);
+            }});
+
+            operationsByType.put(String.class, new EnumMap<OperationType, Operation>(OperationType.class) {{
+                put(OperationType.CREATE, createMetricOperation);
+                put(OperationType.UPDATE, updateMetricOperation);
+                put(OperationType.DELETE, deleteMetricOperation);
+            }});
+
+            operationsByType.put(String.class, new EnumMap<OperationType, Operation>(OperationType.class) {{
+                put(OperationType.ASSOCIATE, associate);
+            }});
+        }
+    }
+
+    private enum OperationType {
+        CREATE, UPDATE, DELETE, COPY, ASSOCIATE
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/Security.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/Security.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.security;
+
+/**
+ * CDI bean that provides inventory-focused abstractions over Hawkular accounts.
+ * It defines all the operations available in inventory and implements permission checking methods.
+ *
+ * @author Lukas Krejci
+ * @since 0.0.2
+ */
+public interface Security {
+
+    boolean canCreate(String path);
+
+    boolean canUpdate(String path);
+
+    boolean canDelete(String path);
+
+    boolean canAssociateFrom(String path);
+
+    boolean canCopyEnvironment(String path);
+
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/SecurityIntegration.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/SecurityIntegration.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.security;
+
+import static org.hawkular.rest.RestApiLogger.LOGGER;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.hawkular.accounts.api.PersonaService;
+import org.hawkular.accounts.api.ResourceService;
+import org.hawkular.accounts.api.model.Persona;
+
+import rx.Subscription;
+
+/**
+ * Integrates the security concerns with the inventory.
+ * <p>
+ * <p>Mutation operations must be checked explicitly in the REST classes using the {@link Security} bean and invoking
+ * one of its {@code can*()} methods. The creation of the security resources associated with the newly created inventory
+ * entities is handled automagically by this class which does that by observing the mutation events on the inventory
+ * .</p>
+ * <p/>
+ * <p>
+ * To completely disable the auth completely do following:
+ * <ul>
+ * (it's commented there).</li>
+ * <li>Set the {@link SecurityIntegration#DUMMY} flag to true in {@link SecurityIntegration} class.</li>
+ * <li>Comment out the secure-deployment element for <code>hawkular-inventory-dist.war</code> in
+ * <a href="http://git.io/vZkQs">dist/src/main/resources/wildfly/patches/standalone.xsl</a> in hawkular/hawkular
+ * repo.</li>
+ * <li>Comment out the keycloak xml elements in <code>jboss-web.xml</code> and <code>web.xml</code>
+ * (it's commented there).</li>
+ * </ul>
+ * </p>
+ * <p>
+ * <strong>NOTE1:</strong> it can be disabled also only partially, for instance if the
+ * be always the same.
+ * </p>
+ * <p>
+ * <strong>NOTE2:</strong> This may be useful to measure the impact of security aspects to the overall performance.
+ * </p>
+ *
+ * @author Lukas Krejci
+ * @since 0.0.2
+ */
+@ApplicationScoped
+public class SecurityIntegration {
+
+    @Inject
+    ResourceService storage;
+
+    @Inject
+    PersonaService personas;
+
+    // this flag is here because even if @AllPermissive security is used all over the code, the @PostConstruct method
+    // in Security class is performed. Same applies for @Observes here, if the event is emitted.
+    private static final boolean DUMMY = false;
+
+    private final Set<Subscription> subscriptions = new HashSet<>();
+
+//    public void start(@Observes InventoryInitialized event) {
+//        if (!isDummy()) {
+//            Inventory inventory = event.getInventory();
+//            install(inventory, Tenant.class);
+//            install(inventory, Environment.class);
+//            install(inventory, Feed.class);
+//            install(inventory, ResourceType.class);
+//            install(inventory, MetricType.class);
+//            install(inventory, Resource.class);
+//            install(inventory, Metric.class);
+//            install(inventory, OperationType.class);
+//            //install(inventory, Relationship.class);
+//        }
+//    }
+
+//    public void stop(@Observes DisposingInventory event) {
+//        if (!isDummy()) {
+//            subscriptions.forEach(Subscription::unsubscribe);
+//            subscriptions.clear();
+//        }
+//    }
+
+//    private <E extends AbstractElement<?, ?>> void install(Inventory inventory, Class<E> cls) {
+//        subscriptions.add(inventory.observable(Interest.in(cls).being(created()))
+//                .subscribe((e) -> react(e, created())));
+//
+//        subscriptions.add(inventory.observable(Interest.in(cls).being(deleted()))
+//                .subscribe((e) -> react(e, deleted())));
+//    }
+
+//    @Transactional
+//    public void react(AbstractElement<?, ?> entity, Action<?, ?> action) {
+//        if (!isDummy()) {
+//            switch (action.asEnum()) {
+//                case CREATED:
+//                    createSecurityResource(entity.getPath());
+//                    break;
+//                case DELETED:
+//                    String stableId = EntityIdUtils.getStableId(entity);
+//                    storage.delete(stableId);
+//                    LOGGER.debugf("Deleted security entity with stable ID '%s' for entity %s", stableId, entity);
+//                    break;
+//            }
+//        }
+//    }
+
+    private org.hawkular.accounts.api.model.Resource createSecurityResource(String stableId) {
+
+        LOGGER.tracef("Creating security entity for %s", stableId);
+
+        org.hawkular.accounts.api.model.Resource res = storage.get(stableId);
+        if (res == null) {
+//            org.hawkular.accounts.api.model.Resource parent = createSecurityResource(path.up());
+            org.hawkular.accounts.api.model.Resource parent = null;
+
+            // if the parent is null, it means we're creating a security resource for the tenant - we need to assign
+            // it an owner. If the parent exists, we need to establish the owner to assign to the current resource
+            Persona owner = personas.getCurrent();
+            if (parent != null) {
+                owner = establishOwner(parent, owner);
+            }
+            res = storage.create(stableId, parent, owner);
+        }
+
+        return res;
+    }
+
+    /**
+     * Establishes the owner. If the owner of the parent is the same as the current user, then create the resource
+     * as being owner-less, inheriting the owner from the parent.
+     */
+    private Persona establishOwner(org.hawkular.accounts.api.model.Resource resource, Persona current) {
+        while (resource != null && resource.getPersona() == null) {
+            resource = resource.getParent();
+        }
+
+        if (resource != null && resource.getPersona().equals(current)) {
+            current = null;
+        }
+
+        return current;
+    }
+
+    public static boolean isDummy() {
+        return DUMMY;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/TenantId.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/TenantId.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.security;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.2.0
+ */
+public class TenantId {
+    private String tenantId;
+
+    protected TenantId() {
+
+    }
+
+    public TenantId(String tenantId) {
+        this.tenantId = tenantId;
+    }
+
+    public String get() {
+        return tenantId;
+    }
+
+    public void set(String tenantId) {
+        this.tenantId = tenantId;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/TenantIdProducer.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/TenantIdProducer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.security;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.0.1
+ */
+public interface TenantIdProducer {
+    TenantId getTenantId();
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/dummy/AllPermissive.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/dummy/AllPermissive.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.security.dummy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.3.4
+ */
+@Qualifier
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AllPermissive {
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/dummy/DummyTenantIdProducer.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/dummy/DummyTenantIdProducer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.security.dummy;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.hawkular.rest.security.TenantId;
+import org.hawkular.rest.security.TenantIdProducer;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.0.1
+ */
+@Singleton
+@AllPermissive
+public class DummyTenantIdProducer implements TenantIdProducer {
+
+    @Override
+    @Produces
+    @AllPermissive
+    public TenantId getTenantId() {
+        return new TenantId("28026b36-8fe4-4332-84c8-524e173a68bf");
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/dummy/PermissiveSecurity.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/dummy/PermissiveSecurity.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rest.security.dummy;
+
+import javax.inject.Singleton;
+
+import org.hawkular.rest.security.Security;
+
+/**
+ * Dummy permissive implementation.
+ *
+ * @author Jirka Kremser
+ * @since 0.3.4
+ */
+@Singleton
+@AllPermissive
+public class PermissiveSecurity implements Security {
+
+    @Override public boolean canCreate(String entityType) {
+        return true;
+    }
+
+    @Override public boolean canUpdate(String path) {
+        return true;
+    }
+
+    @Override public boolean canDelete(String path) {
+        return true;
+    }
+
+    @Override public boolean canAssociateFrom(String path) {
+        return true;
+    }
+
+    @Override public boolean canCopyEnvironment(String path) {
+        return true;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/java/org/hawkular/rest/security/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rest.security;

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/beans.xml
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>
+

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<jboss-deployment-structure>
+  <deployment>
+    <exclusions>
+      <module name="org.jboss.resteasy.resteasy-jackson-provider"/>
+      <module name="org.jboss.resteasy.resteasy-jettison-provider"/>
+    </exclusions>
+    <dependencies>
+      <module name="org.jboss.resteasy.resteasy-jackson2-provider" services="import"/>
+    </dependencies>
+  </deployment>
+</jboss-deployment-structure>

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<jboss-web>
+  <context-root>/hawkular/api</context-root>
+
+  <!-- comment the following line out to disable keycloak auth -->
+  <security-domain>keycloak</security-domain>
+
+</jboss-web>

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/web.xml
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         version="3.1">
+
+  <display-name>Hawkular Rest interface</display-name>
+
+  <context-param>
+    <param-name>resteasy.media.type.mappings</param-name>
+    <param-value>html : text/html, json : application/json, xml : application/xml, csv : text/csv, txt: text/plain,
+      yaml: application/yaml, jsonw: application/vnd.rhq.wrapped+json
+    </param-value>
+  </context-param>
+
+  <!-- to disable the auth, comment out the following elements -->
+  <security-constraint>
+    <web-resource-collection>
+      <web-resource-name>REST endpoints</web-resource-name>
+      <url-pattern>/*</url-pattern>
+    </web-resource-collection>
+    <auth-constraint>
+      <role-name>*</role-name>
+    </auth-constraint>
+  </security-constraint>
+
+  <login-config>
+    <auth-method>KEYCLOAK</auth-method>
+    <realm-name>hawkular</realm-name>
+  </login-config>
+
+  <security-role>
+    <role-name>user</role-name>
+  </security-role>
+  <security-role>
+    <role-name>admin</role-name>
+  </security-role>
+
+  <!-- this filter creates the hystrix context around each incoming request -->
+  <filter>
+    <display-name>HystrixRequestContextServletFilter</display-name>
+    <filter-name>HystrixRequestContextServletFilter</filter-name>
+    <filter-class>com.netflix.hystrix.contrib.requestservlet.HystrixRequestContextServletFilter</filter-class>
+    <async-supported>true</async-supported>
+  </filter>
+  <filter-mapping>
+    <filter-name>HystrixRequestContextServletFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+
+  <!-- this filter logs an INFO message with the output from
+   [HystrixRequestLog.getCurrentRequest().getExecutedCommandsAsString()]-->
+  <filter>
+    <display-name>HystrixRequestLogViaLoggerServletFilter</display-name>
+    <filter-name>HystrixRequestLogViaLoggerServletFilter</filter-name>
+    <filter-class>com.netflix.hystrix.contrib.requestservlet.HystrixRequestLogViaLoggerServletFilter</filter-class>
+    <async-supported>true</async-supported>
+  </filter>
+  <filter-mapping>
+    <filter-name>HystrixRequestLogViaLoggerServletFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+</web-app>

--- a/modules/hawkular-api-parent/hawkular-rx/pom.xml
+++ b/modules/hawkular-api-parent/hawkular-rx/pom.xml
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular</groupId>
+    <artifactId>hawkular-api-parent</artifactId>
+    <version>1.0.0.Alpha9-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>hawkular-rx</artifactId>
+  <version>1.0.0.Alpha9-SNAPSHOT</version>
+
+  <name>Hawkular: RX extensions layer</name>
+  <description>blah</description>
+
+  <properties>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+<!--
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-cdi</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-api</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-impl-tinkerpop</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-bus</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+-->
+    <dependency>
+      <groupId>org.hawkular.inventory</groupId>
+      <artifactId>hawkular-inventory-json-helper</artifactId>
+      <version>${version.org.hawkular.inventory}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.datastax.cassandra</groupId>
+      <artifactId>cassandra-driver-core</artifactId>
+    </dependency>
+
+    <!-- RX -->
+    <dependency>
+      <groupId>com.netflix.hystrix</groupId>
+      <artifactId>hystrix-core</artifactId>
+    </dependency>
+<!--
+    <dependency>
+      <groupId>io.reactivex</groupId>
+      <artifactId>rxjava</artifactId>
+    </dependency>
+-->
+    <!-- these will be provided by our RA - the MDB itself will never need ActiveMQ specific classes -->
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-all</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-jaas</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.accounts</groupId>
+      <artifactId>hawkular-accounts-api</artifactId>
+      <version>1.1.2.Final</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Wildfly provided -->
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-processor</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.transaction</groupId>
+      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp</groupId>
+      <artifactId>okhttp</artifactId>
+      <version>2.6.0</version>
+    </dependency>
+
+    <!-- javadoc requires all the annotations on the classpath -->
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.1-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.interceptor</groupId>
+      <artifactId>javax.interceptor-api</artifactId>
+      <version>1.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.4</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/CreateCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/CreateCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * @author Jirka Kremser
+ */
+@Qualifier
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+@Retention(RUNTIME)
+@Documented
+/**
+ * Use this annotation only if there is an ambiguity
+ * (often the update commands extends the create commands)
+ */
+public @interface CreateCommand {
+
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/CreateCommandLiteral.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/CreateCommandLiteral.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * @author Jirka Kremser
+ */
+public class CreateCommandLiteral extends AnnotationLiteral<CreateCommand> implements CreateCommand {
+    private static final CreateCommandLiteral INSTANCE = new CreateCommandLiteral();
+
+    public static CreateCommandLiteral get() {
+        return INSTANCE;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/Initialized.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/Initialized.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+/**
+ * @author Jirka Kremser
+ */
+public final class Initialized {
+
+    public static WithValuesLiteral withValues(String... values) {
+        return new WithValuesLiteral(values);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/JacksonConfig.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/JacksonConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Provider;
+
+import org.hawkular.inventory.api.model.CanonicalPath;
+import org.hawkular.inventory.api.model.RelativePath;
+import org.hawkular.inventory.json.InventoryJacksonConfig;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * @author Jirka Kremser
+ * @since 0.1.0
+ */
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class JacksonConfig implements ContextResolver<ObjectMapper> {
+
+    private ObjectMapper mapper;
+
+
+    public JacksonConfig() {
+        this.mapper = new ObjectMapper();
+        initializeObjectMapper(this.mapper);
+
+//        SimpleModule relationshipModule = new SimpleModule("RelationshipModule",
+//                new Version(0, 1, 0, null, "org.hawkular.inventory",
+//                        "inventory-rest-api"));
+//        relationshipModule.addSerializer(Relationship.class, new RelationshipJacksonSerializer());
+//        relationshipModule.addDeserializer(Relationship.class, new RelationshipJacksonDeserializer());
+//
+//        this.mapper.registerModule(relationshipModule);
+    }
+
+    public static void initializeObjectMapper(ObjectMapper mapper) {
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.disable(SerializationFeature.WRITE_NULL_MAP_VALUES);
+        mapper.disable(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        mapper.enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES);
+        mapper.enable(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        InventoryJacksonConfig.configure(mapper);
+        //need to reconfigure for path serialization
+        mapper.addMixIn(CanonicalPath.class, PathSerializationMixin.class);
+        mapper.addMixIn(RelativePath.class, PathSerializationMixin.class);
+    }
+
+    @Override public ObjectMapper getContext(Class<?> type) {
+        return mapper;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/MessageDigestProvider.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/MessageDigestProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+/**
+ * @author Jirka Kremser
+ */
+@Singleton
+public class MessageDigestProvider {
+
+    private MessageDigest md5;
+
+    @Produces
+    public MessageDigest getMD5() {
+        if (md5 == null) {
+            try {
+                this.md5 = MessageDigest.getInstance("MD5");
+            } catch (NoSuchAlgorithmException e) {
+                e.printStackTrace();
+            }
+        }
+        return md5;
+    }
+
+
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/ObjectMapperProvider.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/ObjectMapperProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Produces;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Lukas Krejci
+ * @since 0.4.0
+ */
+public class ObjectMapperProvider {
+
+    private final JacksonConfig config = new JacksonConfig();
+
+    @Produces
+    @Default
+    public ObjectMapper getDefaultObjectMapper() {
+        return config.getContext(ObjectMapper.class);
+    }
+
+//    @Produces
+//    @JsonLd
+//    public ObjectMapper getJsonLdObjectMapper() {
+//        return config.getContext(EmbeddedObjectMapper.class);
+//    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/PathSerializationMixin.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/PathSerializationMixin.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import org.hawkular.inventory.json.DetypedPathDeserializer;
+import org.hawkular.inventory.json.PathSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * We need to deserialize paths manually in REST API, because we cannot provide the default
+ * {@link DetypedPathDeserializer} with enough info in the early stages of request processing.
+ * <p>
+ * <p>So we need to configure it with a custom mixin that will be used just for serialization. Note that the paths
+ * are serialized <b>WITH</b> the tenant ID included, even though REST API can accept paths WITHOUT a tenant ID and
+ * automagically modify the paths to include the current tenant ID in them. This is so that the clients that use the
+ * paths obtained from the inventory server can use them as opaque identifiers without any requirements on processing
+ * them before passing them along further. The paths obtained from inventory are the "true" stuff, but inventory is
+ * kind enough to let the clients produce simpler, tenant-less, paths when talking to it.
+ *
+ * @author Lukas Krejci
+ * @see JacksonConfig
+ * @since 0.2.0
+ */
+@JsonSerialize(using = PathSerializer.class)
+public final class PathSerializationMixin {
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/UpdateCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/UpdateCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * @author Jirka Kremser
+ */
+@Qualifier
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+@Retention(RUNTIME)
+@Documented
+/**
+ * Use this annotation only if there is an ambiguity
+ * (often the update commands extends the create commands)
+ */
+public @interface UpdateCommand {
+
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/UpdateCommandLiteral.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/UpdateCommandLiteral.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * @author Jirka Kremser
+ */
+public class UpdateCommandLiteral extends AnnotationLiteral<UpdateCommand> implements UpdateCommand {
+    private static final UpdateCommandLiteral INSTANCE = new UpdateCommandLiteral();
+
+    public static UpdateCommandLiteral get() {
+        return INSTANCE;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/WithValues.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/WithValues.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+/**
+ * @author Jirka Kremser
+ */
+@Qualifier
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+@Retention(RUNTIME)
+@Documented
+public @interface WithValues {
+
+    @Nonbinding String[] values() default {};
+
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/WithValuesLiteral.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/WithValuesLiteral.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Objects;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * @author Jirka Kremser
+ */
+public class WithValuesLiteral extends AnnotationLiteral<WithValues> implements WithValues {
+
+    private final String[] values;
+
+    public WithValuesLiteral(String... values) {
+        this.values = values;
+    }
+
+    @Override public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        WithValuesLiteral that = (WithValuesLiteral) o;
+        return Objects.equals(values, that.values);
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(super.hashCode(), values);
+    }
+
+    @Override public String toString() {
+        final StringBuilder sb = new StringBuilder("WithValuesLiteral[");
+        sb.append("values=").append(Arrays.toString(values));
+        sb.append(']');
+        return sb.toString();
+    }
+
+    @Override public Class<? extends Annotation> annotationType() {
+        return WithValues.class;
+    }
+
+    @Override public String[] values() {
+        return values;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/cdi/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.cdi;

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/alerts/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/alerts/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rx.commands.alerts;

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/AbstractHttpCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/AbstractHttpCommand.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.common;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.spi.InjectionPoint;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.rx.cdi.WithValues;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+import com.netflix.hystrix.HystrixObservableCommand;
+
+/**
+ * @author Jirka Kremser
+ */
+public abstract class AbstractHttpCommand<R> extends HystrixObservableCommand<R> {
+
+    private AbstractHttpCommand() {
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("Other"))
+                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
+                        .withExecutionTimeoutInMilliseconds(2500)));
+    }
+
+    protected AbstractHttpCommand(HystrixCommandGroupKey group) {
+        super(Setter.withGroupKey(group).andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
+                .withExecutionTimeoutInMilliseconds(2500)));
+    }
+
+    protected AbstractHttpCommand(Setter setter) {
+        super(setter);
+    }
+
+    protected abstract List<ImmutablePair<Class, Consumer>> getSetters();
+
+    protected void initialize(InjectionPoint ip) {
+        boolean annotationFound = false;
+        for (Annotation annotation : ip.getQualifiers()) {
+            if (annotation.annotationType().equals(WithValues.class)) {
+                annotationFound = true;
+                String[] values = ((WithValues) annotation).values();
+                List<ImmutablePair<Class, Consumer>> setters = getSetters();
+                if (values.length != setters.size()) {
+                    throw new IllegalStateException("@WithValues has different number of parameters than it's needed");
+                }
+                int index = 0;
+                for (ImmutablePair<Class, Consumer> setter : setters) {
+                    if (values[index] == null) {
+                        setter.getRight().accept(null);
+                    }
+                    if (setter.getLeft().equals(String.class)) {
+                        setter.getRight().accept(values[index]);
+                    } else if (setter.getLeft().equals(int.class) || setter.getLeft().equals(Integer.class)) {
+                        setter.getRight().accept(Integer.parseInt(values[index]));
+                    } else if (setter.getLeft().equals(boolean.class) || setter.getLeft().equals(Boolean.class)) {
+                        setter.getRight().accept(Boolean.parseBoolean(values[index]));
+                    } else if (setter.getLeft().equals(long.class) || setter.getLeft().equals(Long.class)) {
+                        setter.getRight().accept(Boolean.parseBoolean(values[index]));
+                    } else if (setter.getLeft().equals(double.class) || setter.getLeft().equals(Double.class)) {
+                        setter.getRight().accept(Double.parseDouble(values[index]));
+                    }
+                    index++;
+                }
+                break;
+            }
+        }
+        if (!annotationFound) {
+            throw new IllegalStateException("No @WithValues on InjectionPoint");
+        }
+    }
+
+    protected String nullOrStr(Object input) {
+        return input == null ? null : String.valueOf(input);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/HawkularConfiguration.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/HawkularConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.common;
+
+import javax.inject.Singleton;
+
+/**
+ * @author Jirka Kremser
+ */
+@Singleton
+public class HawkularConfiguration {
+
+    // todo: this class is temporary, it should use some property file or sysprops
+    public static final String URL_ACCOUNTS = "http://127.0.0.1:8080/hawkular/accounts";
+    public static final String URL_BTM = "http://127.0.0.1:8080/hawkular/btm";
+    public static final String URL_ALERTS = "http://127.0.0.1:8080/hawkular/alerts";
+    public static final String URL_INVENTORY = "http://127.0.0.1:8080/hawkular/inventory";
+    public static final String URL_METRICS = "http://127.0.0.1:8080/hawkular/metrics";
+
+
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rx.commands.common;

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/CreateUrlCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/CreateUrlCommand.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.hawkular;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.MessageDigest;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.inventory.api.model.CanonicalPath;
+import org.hawkular.inventory.api.model.Metric;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.rx.cdi.CreateCommand;
+import org.hawkular.rx.cdi.Initialized;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.common.AbstractHttpCommand;
+import org.hawkular.rx.commands.common.HawkularConfiguration;
+import org.hawkular.rx.commands.inventory.CreateMetricCommand;
+import org.hawkular.rx.commands.inventory.CreateResourceCommand;
+import org.hawkular.rx.httpclient.HttpClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+@CreateCommand
+public class CreateUrlCommand extends AbstractHttpCommand<String> {
+
+    protected String url;
+
+    protected String authToken;
+
+    protected String persona;
+
+    @Inject
+    protected HttpClient client;
+
+    @Inject
+    @Any
+    protected ObjectMapper mapper;
+
+    @Inject
+    private MessageDigest md5;
+
+    @Inject
+    protected HawkularConfiguration config;
+
+    @Inject
+    @Any
+    private Instance<CreateResourceCommand> createResourceCommandInjector;
+
+    @Inject
+    @Any
+    private Instance<CreateMetricCommand> createMetricCommandInjector;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> CreateUrlCommand.this.url = makeUrlWithProtocol(nullOrStr(x))),
+                new ImmutablePair<>(String.class, (x) -> CreateUrlCommand.this.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> CreateUrlCommand.this.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    protected CreateUrlCommand(InjectionPoint ip) {
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("URL"))
+                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
+                        .withExecutionTimeoutInMilliseconds(3500)));
+        initialize(ip);
+    }
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                try {
+                    if (observer.isUnsubscribed()) {
+                        return;
+                    }
+                    CreateResourceCommand createResourceCmd =
+                            createResourceCommandInjector.select(Initialized.withValues(authToken, persona)).get();
+
+                    String hashedUrl = md5Hash(url);
+                    Resource.Blueprint urlBlueprint = Resource.Blueprint.builder()
+                            .withId(hashedUrl)
+                            .withResourceTypePath(CanonicalPath.of().tenant(persona)
+                                    .resourceType("URL").get().toString())
+                            .withProperty("url", url)
+                            .withProperty("hwk-gui-domainSort", getDomainSorterUrl(url))
+                            .build();
+                    createResourceCmd.setResource(urlBlueprint);
+                    Observable<String> observeResource = createResourceCmd.toObservable();
+
+                    Metric.Blueprint metric1 = Metric.Blueprint.builder()
+                            .withId(hashedUrl + ".status.duration")
+                            .withMetricTypePath(CanonicalPath.of().tenant(persona)
+                                    .metricType("status.duration.type").get().toString())
+                            .build();
+                    CreateMetricCommand metric1Cmd =
+                            createMetricCommandInjector.select(Initialized.withValues(authToken, persona)).get();
+                    metric1Cmd.setResourcePath(hashedUrl);
+                    metric1Cmd.setMetric(metric1);
+                    Metric.Blueprint metric2 = Metric.Blueprint.builder()
+                            .withId(hashedUrl + ".status.code")
+                            .withMetricTypePath(CanonicalPath.of().tenant(persona)
+                                    .metricType("status.code.type").get().toString())
+                            .build();
+                    CreateMetricCommand metric2Cmd =
+                            createMetricCommandInjector.select(Initialized.withValues(authToken, persona)).get();
+                    metric2Cmd.setResourcePath(hashedUrl);
+                    metric2Cmd.setMetric(metric2);
+
+                    Observable<String> observeMetric1 = metric1Cmd.toObservable();
+                    Observable<String> observeMetric2 = metric2Cmd.toObservable();
+
+                    observeResource.concatWith(observeMetric1.mergeWith(observeMetric2)).buffer(3)
+                            .doOnError(e -> {
+                                System.err.println(e);
+                                observer.onError(e);
+                            }).subscribe((commandResponse) -> {
+                                observer.onNext(commandResponse.get(0));
+                                observer.onCompleted();
+                    });
+
+//                    observeResource.flatMap((response) -> observeMetrics).subscribe((commandResponse) -> {
+//                        observer.onNext(commandResponse);
+//                    });
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+
+//    @Override
+//    protected String getCacheKey() {
+//        return url;
+//    }
+
+//    @Override
+//    protected Observable<String> resumeWithFallback() {
+//        return Observable.just(url);
+//    }
+
+    private String md5Hash(String input) {
+        byte[] byteData = md5.digest(input.getBytes());
+        StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < byteData.length; i++)
+            sb.append(Integer.toString((byteData[i] & 0xff) + 0x100, 16).substring(1));
+        return sb.toString();
+    }
+
+    protected String makeUrlWithProtocol(String url) {
+        return url.startsWith("http") ? url : "http://" + url;
+    }
+
+    protected String getDomainSorterUrl(String url) {
+        //http://git.io/vRIHB
+        try {
+            URL urlInstance = new URL(url);
+            String[] levels = urlInstance.getHost().split(".");
+            if (levels != null && levels.length > 1) {
+                String[] levelsSorted = new String[levels.length];
+                //"a.b.redhat.com" will produce "redhat.com.a.b"
+                Arrays.setAll(levelsSorted, i -> {
+                    switch (i) {
+                        case 0:
+                        case 1:
+                            String level = levels[levels.length - 1 - i];
+                            //replace all the www's with a space so that they sort before any other name
+                            return "www".equals(level) ? " " : level;
+                        default:
+                            level = levels[i];
+                            return "www".equals(level) ? " " : level;
+                    }
+                });
+                return StringUtils.join(levelsSorted, ".");
+            }
+            return url;
+        } catch (MalformedURLException e) {
+            return url;
+        }
+
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/DeleteUrlCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/DeleteUrlCommand.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.hawkular;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.rx.cdi.Initialized;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.common.AbstractHttpCommand;
+import org.hawkular.rx.commands.common.HawkularConfiguration;
+import org.hawkular.rx.commands.inventory.DeleteMetricCommand;
+import org.hawkular.rx.commands.inventory.DeleteResourceCommand;
+import org.hawkular.rx.httpclient.HttpClient;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+public class DeleteUrlCommand extends AbstractHttpCommand<String> {
+
+    protected String urlId;
+
+    protected String authToken;
+
+    protected String persona;
+
+    @Inject
+    protected HttpClient client;
+
+    @Inject
+    protected HawkularConfiguration config;
+
+    @Inject
+    @Any
+    private Instance<DeleteResourceCommand> deleteResourceCommandInjector;
+
+    @Inject
+    @Any
+    private Instance<DeleteMetricCommand> deleteMetricCommandInjector;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> DeleteUrlCommand.this.urlId = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> DeleteUrlCommand.this.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> DeleteUrlCommand.this.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    protected DeleteUrlCommand(InjectionPoint ip) {
+        super(HystrixCommandGroupKey.Factory.asKey("URL"));
+        initialize(ip);
+    }
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                if (observer.isUnsubscribed()) {
+                    return;
+                }
+                try {
+                    // todo: deleting the resource itself should be enough (no need to delete the metrics first)
+
+                    final String metric1Id = urlId + ".status.duration";
+                    final String metric2Id = urlId + ".status.code";
+
+                    DeleteMetricCommand deleteMetric1Cmd =
+                            deleteMetricCommandInjector.select(Initialized.withValues(metric1Id, authToken, persona))
+                                    .get();
+                    deleteMetric1Cmd.setResourcePath(urlId);
+                    DeleteMetricCommand deleteMetric2Cmd =
+                            deleteMetricCommandInjector.select(Initialized.withValues(metric2Id, authToken, persona))
+                                    .get();
+                    deleteMetric2Cmd.setResourcePath(urlId);
+
+                    DeleteResourceCommand deleteResourceCmd =
+                            deleteResourceCommandInjector.select(Initialized.withValues(urlId, authToken, persona))
+                                    .get();
+
+                    Observable<String> observeCmd1 = deleteMetric1Cmd.toObservable();
+                    Observable<String> observeCmd2 = deleteMetric2Cmd.toObservable();
+                    Observable<String> observeDeleteResource = deleteResourceCmd.toObservable();
+
+                    // make the first 2 calls in parallel and the third one after they finish
+                    observeCmd1
+                            .zipWith(observeCmd2, (first, second) -> new ImmutablePair(first, second))
+                            .flatMap((pair) -> observeDeleteResource).buffer(2).subscribe((aggregatedCmdResponse) -> {
+                        observer.onNext(aggregatedCmdResponse.get(1));
+                        observer.onCompleted();
+                    });
+
+//                    observeCmd1.mergeWith(observeCmd2).concatWith(observeDeleteResource).subscribe(
+//                            (commandResponse) -> {
+//                                observer.onNext(commandResponse);
+//                            });
+
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+
+//    @Override
+//    protected String getCacheKey() {
+//        return urlId;
+//    }
+
+    @Override
+    protected Observable<String> resumeWithFallback() {
+        return Observable.just(urlId);
+    }
+
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/GetUrlCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/GetUrlCommand.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.hawkular;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.common.AbstractHttpCommand;
+import org.hawkular.rx.commands.common.HawkularConfiguration;
+import org.hawkular.rx.httpclient.HttpClient;
+import org.hawkular.rx.httpclient.RestResponse;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+public class GetUrlCommand extends AbstractHttpCommand<String> {
+
+    private String id;
+
+    private String authToken;
+
+    private String persona;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> GetUrlCommand.this.id = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> GetUrlCommand.this.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> GetUrlCommand.this.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    private HttpClient client;
+
+    @Inject
+    private HawkularConfiguration config;
+
+    @Inject
+    private GetUrlCommand(InjectionPoint ip) {
+        super(HystrixCommandGroupKey.Factory.asKey("URL"));
+        initialize(ip);
+    }
+
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                if (observer.isUnsubscribed()) {
+                    return;
+                }
+                try {
+                    String url = id == null || id.trim().isEmpty() ?
+                            config.URL_INVENTORY + "/resourceTypes/URL/resources" :
+                            config.URL_INVENTORY + "/test/resources/" + id;
+                    RestResponse response = client.get(authToken, persona, url);
+
+                    observer.onNext(response.getBody());
+                    observer.onCompleted();
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+
+//    @Override
+//    protected String getCacheKey() {
+//        return id;
+//    }
+
+    @Override
+    protected Observable<String> resumeWithFallback() {
+        return Observable.just(id);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/UpdateUrlCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/UpdateUrlCommand.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.hawkular;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.rx.cdi.Initialized;
+import org.hawkular.rx.cdi.UpdateCommand;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.inventory.UpdateResourceCommand;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+@UpdateCommand
+public class UpdateUrlCommand extends CreateUrlCommand {
+
+    private String urlId;
+
+    @Inject
+    @Any
+    private Instance<UpdateResourceCommand> updateResourceCommandInjector;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> UpdateUrlCommand.this.urlId = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> UpdateUrlCommand.this.url = makeUrlWithProtocol(nullOrStr(x))),
+                new ImmutablePair<>(String.class, (x) -> UpdateUrlCommand.this.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> UpdateUrlCommand.this.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    private UpdateUrlCommand(InjectionPoint ip) {
+        super(ip);
+    }
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                if (observer.isUnsubscribed()) {
+                    return;
+                }
+                try {
+                    UpdateResourceCommand updateResourceCmd =
+                            updateResourceCommandInjector.select(Initialized.withValues(urlId, authToken, persona))
+                                    .get();
+
+                    Resource.Update urlUpdate = Resource.Update.builder()
+                            .withProperty("url", url)
+                            .withProperty("hwk-gui-domainSort", getDomainSorterUrl(url))
+                            .build();
+                    updateResourceCmd.setResource(urlUpdate);
+                    Observable<String> observeResource = updateResourceCmd.toObservable();
+
+                    observeResource.subscribe((commandResponse) -> {
+                        observer.onNext(commandResponse);
+                    });
+
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rx.commands.hawkular;

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/CreateMetricCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/CreateMetricCommand.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.inventory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.inventory.api.model.Metric;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.common.AbstractHttpCommand;
+import org.hawkular.rx.commands.common.HawkularConfiguration;
+import org.hawkular.rx.httpclient.HttpClient;
+import org.hawkular.rx.httpclient.RestResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+public class CreateMetricCommand extends AbstractHttpCommand<String> {
+
+    private Metric.Blueprint metric;
+
+    private String resourcePath;
+
+    private String authToken;
+
+    private String persona;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        final CreateMetricCommand self = CreateMetricCommand.this;
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> self.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> self.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    private HttpClient client;
+
+    @Inject
+    @Any
+    private ObjectMapper mapper;
+
+    @Inject
+    private HawkularConfiguration config;
+
+    @Inject
+    private CreateMetricCommand(InjectionPoint ip) {
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("inventory-metric"))
+                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
+                        .withExecutionTimeoutInMilliseconds(1500)));
+        initialize(ip);
+    }
+
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                if (observer.isUnsubscribed()) {
+                    return;
+                }
+                try {
+                    String url;
+                    if (resourcePath != null) {
+                        url = config.URL_INVENTORY + "/test/resources/" + resourcePath + "/metrics";
+                    } else {
+                        url = config.URL_INVENTORY + "/test/metrics";
+                    }
+                    RestResponse response = client.post(authToken, persona, url, mapper.writeValueAsString(metric));
+
+                    observer.onNext(response.getLocationHeader());
+                    observer.onCompleted();
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+
+    public void setMetric(Metric.Blueprint metric) {
+        this.metric = metric;
+    }
+
+    public void setResourcePath(String resourcePath) {
+        this.resourcePath = resourcePath;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/CreateResourceCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/CreateResourceCommand.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.inventory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.common.AbstractHttpCommand;
+import org.hawkular.rx.commands.common.HawkularConfiguration;
+import org.hawkular.rx.httpclient.HttpClient;
+import org.hawkular.rx.httpclient.RestResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.HystrixCommandProperties;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+public class CreateResourceCommand extends AbstractHttpCommand<String> {
+
+    private Resource.Blueprint resource;
+
+    private String authToken;
+
+    private String persona;
+
+    @Inject
+    @Any
+    private Instance<CreateResourceCommand> createResourceCommandInjector;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        final CreateResourceCommand self = CreateResourceCommand.this;
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> self.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> self.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    private HttpClient client;
+
+    @Inject
+    @Any
+    private ObjectMapper mapper;
+
+    @Inject
+    private HawkularConfiguration config;
+
+    @Inject
+    private CreateResourceCommand(InjectionPoint ip) {
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("inventory-resource"))
+                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
+                        .withExecutionTimeoutInMilliseconds(2500)));
+        initialize(ip);
+    }
+
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                if (observer.isUnsubscribed()) {
+                    return;
+                }
+                try {
+                    RestResponse response =
+                            client.post(authToken, persona, config.URL_INVENTORY + "/test/resources",
+                                    mapper.writeValueAsString(resource));
+
+                    observer.onNext(response.getLocationHeader());
+                    observer.onCompleted();
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+
+    public void setResource(Resource.Blueprint resource) {
+        this.resource = resource;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/DeleteMetricCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/DeleteMetricCommand.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.inventory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.common.AbstractHttpCommand;
+import org.hawkular.rx.commands.common.HawkularConfiguration;
+import org.hawkular.rx.httpclient.HttpClient;
+import org.hawkular.rx.httpclient.RestResponse;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+public class DeleteMetricCommand extends AbstractHttpCommand<String> {
+
+    private String metricId;
+
+    private String resourcePath;
+
+    private String authToken;
+
+    private String persona;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        final DeleteMetricCommand self = DeleteMetricCommand.this;
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> self.metricId = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> self.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> self.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    private HttpClient client;
+
+    @Inject
+    private HawkularConfiguration config;
+
+    @Inject
+    private DeleteMetricCommand(InjectionPoint ip) {
+        super(HystrixCommandGroupKey.Factory.asKey("inventory-metric"));
+        initialize(ip);
+    }
+
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                if (observer.isUnsubscribed()) {
+                    return;
+                }
+                try {
+                    String url;
+                    if (resourcePath != null) {
+                        url = config.URL_INVENTORY + "/test/resources/" + resourcePath + "/metrics/" + metricId;
+                    } else {
+                        url = config.URL_INVENTORY + "/test/metrics/" + metricId;
+                    }
+                    RestResponse response = client.delete(authToken, persona, url);
+
+                    observer.onNext(response.getBody());
+                    observer.onCompleted();
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+
+    public void setResourcePath(String resourcePath) {
+        this.resourcePath = resourcePath;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/DeleteResourceCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/DeleteResourceCommand.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.inventory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.common.AbstractHttpCommand;
+import org.hawkular.rx.commands.common.HawkularConfiguration;
+import org.hawkular.rx.httpclient.HttpClient;
+import org.hawkular.rx.httpclient.RestResponse;
+
+import com.netflix.hystrix.HystrixCommandGroupKey;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+public class DeleteResourceCommand extends AbstractHttpCommand<String> {
+
+    private String resourceId;
+
+    private String authToken;
+
+    private String persona;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        final DeleteResourceCommand self = DeleteResourceCommand.this;
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> self.resourceId = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> self.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> self.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    private HttpClient client;
+
+    @Inject
+    private HawkularConfiguration config;
+
+    @Inject
+    private DeleteResourceCommand(InjectionPoint ip) {
+        super(HystrixCommandGroupKey.Factory.asKey("inventory-resource"));
+        initialize(ip);
+    }
+
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                if (observer.isUnsubscribed()) {
+                    return;
+                }
+                try {
+                    RestResponse response =
+                            client.delete(authToken, persona, config.URL_INVENTORY + "/test/resources/" + resourceId);
+
+                    observer.onNext(response.getBody());
+                    observer.onCompleted();
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/UpdateResourceCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/UpdateResourceCommand.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.inventory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.inventory.api.model.Resource;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.common.AbstractHttpCommand;
+import org.hawkular.rx.commands.common.HawkularConfiguration;
+import org.hawkular.rx.httpclient.HttpClient;
+import org.hawkular.rx.httpclient.RestResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+public class UpdateResourceCommand extends AbstractHttpCommand<String> {
+
+    private Resource.Update resource;
+
+    private String resourceId;
+
+    private String authToken;
+
+    private String persona;
+
+    @Inject
+    @Any
+    private Instance<UpdateResourceCommand> createResourceCommandInjector;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        final UpdateResourceCommand self = UpdateResourceCommand.this;
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> self.resourceId = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> self.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> self.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    private HttpClient client;
+
+    @Inject
+    @Any
+    private ObjectMapper mapper;
+
+    @Inject
+    private HawkularConfiguration config;
+
+    @Inject
+    private UpdateResourceCommand(InjectionPoint ip) {
+        super(HystrixCommandGroupKey.Factory.asKey("inventory-resource"));
+        initialize(ip);
+    }
+
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                if (observer.isUnsubscribed()) {
+                    return;
+                }
+                try {
+                    RestResponse response =
+                            client.put(authToken, persona, config.URL_INVENTORY + "/test/resources/" + resourceId,
+                                    mapper.writeValueAsString(resource));
+
+                    observer.onNext(response.getBody());
+                    observer.onCompleted();
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+
+    public void setResource(Resource.Update resource) {
+        this.resource = resource;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @author Jirka Kremser
+ */
+package org.hawkular.rx.commands.inventory;

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/metrics/CreateMetricCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/metrics/CreateMetricCommand.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.metrics;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.hawkular.inventory.api.model.Metric;
+import org.hawkular.rx.cdi.WithValues;
+import org.hawkular.rx.commands.common.AbstractHttpCommand;
+import org.hawkular.rx.commands.common.HawkularConfiguration;
+import org.hawkular.rx.httpclient.HttpClient;
+import org.hawkular.rx.httpclient.RestResponse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.hystrix.HystrixCommandGroupKey;
+
+import rx.Observable;
+import rx.Subscriber;
+
+/**
+ * @author Jirka Kremser
+ */
+@WithValues
+public class CreateMetricCommand extends AbstractHttpCommand<String> {
+
+    private Metric.Blueprint metric;
+
+    private String authToken;
+
+    private String persona;
+
+    private String resourcePath;
+
+    @Override
+    protected List<ImmutablePair<Class, Consumer>> getSetters() {
+        final CreateMetricCommand self = CreateMetricCommand.this;
+        return Arrays.asList(
+                new ImmutablePair<>(String.class, (x) -> self.authToken = nullOrStr(x)),
+                new ImmutablePair<>(String.class, (x) -> self.persona = nullOrStr(x))
+        );
+    }
+
+    @Inject
+    private HttpClient client;
+
+    @Inject
+    private ObjectMapper mapper;
+
+    @Inject
+    private HawkularConfiguration config;
+
+    @Inject
+    private CreateMetricCommand(InjectionPoint ip) {
+        super(HystrixCommandGroupKey.Factory.asKey("metric-metric"));
+        initialize(ip);
+    }
+
+
+    @Override protected Observable<String> construct() {
+        return Observable.create(new Observable.OnSubscribe<String>() {
+            @Override
+            public void call(Subscriber<? super String> observer) {
+                try {
+                    // todo: finish
+                    String url;
+                    if (resourcePath != null) {
+                        url = config.URL_METRICS + "/test/resources/" + resourcePath + "/metrics";
+                    } else {
+                        url = config.URL_METRICS + "/test/metrics";
+                    }
+                    RestResponse response = client.post(authToken, persona, url, mapper.writeValueAsString(metric));
+
+                    observer.onNext(response.getLocationHeader());
+                    observer.onCompleted();
+                } catch (Exception e) {
+                    observer.onError(e);
+                }
+            }
+        });
+    }
+
+    public void setMetric(Metric.Blueprint metric) {
+        this.metric = metric;
+    }
+
+    public void setResourcePath(String resourcePath) {
+        this.resourcePath = resourcePath;
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/metrics/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/metrics/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands.metrics;

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.commands;

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/httpclient/HttpClient.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/httpclient/HttpClient.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.httpclient;
+
+import java.io.IOException;
+
+/**
+ * Created by jkremser on 12/2/15.
+ */
+
+public interface HttpClient {
+
+    RestResponse post(String authToken, String persona, String url, String json) throws IOException;
+
+    RestResponse get(String authToken, String persona, String url) throws IOException;
+
+    RestResponse put(String authToken, String persona, String url, String json) throws IOException;
+
+    RestResponse delete(String authToken, String persona, String url) throws IOException;
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/httpclient/OkClient.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/httpclient/OkClient.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.httpclient;
+
+import java.io.IOException;
+
+import javax.enterprise.inject.Default;
+
+import com.squareup.okhttp.MediaType;
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.RequestBody;
+import com.squareup.okhttp.Response;
+
+/**
+ * @author Jirka Kremser
+ */
+@Default
+public class OkClient implements HttpClient {
+
+    public static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+    private final OkHttpClient delegatingClient = new OkHttpClient();
+
+    public RestResponse post(String authToken, String persona, String url, String json) throws IOException {
+        RequestBody body = RequestBody.create(JSON, json);
+        Request request = new Request.Builder()
+                .url(url)
+                .addHeader("Authorization", authToken)
+                .addHeader("Hawkular-Persona", persona)
+                .post(body)
+                .build();
+//        this.delegatingClient.interceptors().add(null);
+
+        Response response = this.delegatingClient.newCall(request).execute();
+
+        // todo: async
+//        Response response = this.delegatingClient.newCall(request).enqueue(new Callback() {
+//            @Override public void onFailure(Request request, IOException e) {
+//
+//            }
+//
+//            @Override public void onResponse(Response response) throws IOException {
+//
+//            }
+//        });
+        return new RestResponse(response);
+    }
+
+    public RestResponse get(String authToken, String persona, String url) throws IOException {
+        Request request = new Request.Builder()
+                .url(url)
+                .addHeader("Authorization", authToken)
+                .addHeader("Hawkular-Persona", persona)
+                .get()
+                .build();
+
+        Response response = this.delegatingClient.newCall(request).execute();
+        return new RestResponse(response);
+    }
+
+    public RestResponse put(String authToken, String persona, String url, String json) throws IOException {
+        RequestBody body = RequestBody.create(JSON, json);
+        Request request = new Request.Builder()
+                .url(url)
+                .addHeader("Authorization", authToken)
+                .addHeader("Hawkular-Persona", persona)
+                .put(body)
+                .build();
+
+        Response response = this.delegatingClient.newCall(request).execute();
+        return new RestResponse(response);
+    }
+
+    public RestResponse delete(String authToken, String persona, String url) throws IOException {
+        Request request = new Request.Builder()
+                .url(url)
+                .addHeader("Authorization", authToken)
+                .addHeader("Hawkular-Persona", persona)
+                .delete()
+                .build();
+
+        Response response = this.delegatingClient.newCall(request).execute();
+        return new RestResponse(response);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/httpclient/RestResponse.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/httpclient/RestResponse.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx.httpclient;
+
+import java.io.IOException;
+
+import com.squareup.okhttp.Response;
+
+/**
+ * @author Jirka Kremser
+ */
+public class RestResponse {
+    private static final String HEADER_LOCATION = "Location";
+
+    private final Response delegatingResponse;
+
+    public RestResponse(Response delegatingResponse) {
+        this.delegatingResponse = delegatingResponse;
+    }
+
+    public String getBody() throws IOException {
+        return delegatingResponse.body().string();
+    }
+
+    public String getHeader(String header) {
+        return delegatingResponse.header(header);
+    }
+
+    public String getLocationHeader() {
+        return delegatingResponse.header(HEADER_LOCATION);
+    }
+}

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/package-info.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.rx;

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/resources/META-INF/beans.xml
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>

--- a/modules/hawkular-api-parent/pom.xml
+++ b/modules/hawkular-api-parent/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.hawkular</groupId>
+    <artifactId>hawkular</artifactId>
+    <version>1.0.0.Alpha9-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>hawkular-api-parent</artifactId>
+  <version>1.0.0.Alpha9-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <name>Hawkular: API parent pom</name>
+  <description>Common pom for rest api module and RX extensions module, to be able to build them together.</description>
+
+  <modules>
+    <module>hawkular-rest-api</module>
+    <module>hawkular-rx</module>
+  </modules>
+
+  <properties>
+  </properties>
+</project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
     <module>modules/hawkular-wildfly-agent-download</module>
     <module>modules/pinger</module>
     <module>modules/avail-creator</module>
+    <module>modules/hawkular-api-parent</module>
     <module>dist</module>
     <module>modules/end-to-end-test</module>
   </modules>
@@ -90,6 +91,9 @@
     <version.org.hawkular.inventory>0.12.0.Final</version.org.hawkular.inventory>
     <version.org.hawkular.metrics>0.11.0.Final-SRC-revision-7a90403c761cc446b1bc357eaac351d58ded00f4</version.org.hawkular.metrics>
     <version.org.keycloak.secretstore>1.0.4.Final</version.org.keycloak.secretstore>
+    <version.rxjava>1.0.16</version.rxjava>
+    <version.hystrix-core>1.4.21</version.hystrix-core>
+    <version.hystrix-request-servlet>1.1.2</version.hystrix-request-servlet>
   </properties>
 
   <dependencyManagement>
@@ -183,6 +187,24 @@
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>${version.commons.io}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.netflix.hystrix</groupId>
+        <artifactId>hystrix-core</artifactId>
+        <version>${version.hystrix-core}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.netflix.hystrix</groupId>
+        <artifactId>hystrix-request-servlet</artifactId>
+        <version>${version.hystrix-request-servlet}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.reactivex</groupId>
+        <artifactId>rxjava</artifactId>
+        <version>${version.rxjava}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
It's a new war living under the `/modules/`

Currently it's only capable of CRUDing the URLs with all the magic behind it (except pre-creation of alerts, this will be the next step)

It uses the [Hystrix](https://github.com/Netflix/Hystrix) library and java rx, so each operation is basically encapsulated as a Hystrix command with possible fallbacks if the backend is not there. Hystrix inherently supports the [Circuit breaker pattern](https://github.com/Netflix/Hystrix/wiki/How-it-Works#CircuitBreaker), so it will be possible to fallback to some dummy response if the system is overloaded and other interesting features.