### PR TITLE
Upgrade to inventory 0.10.1.Final.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <version.org.hawkular.commons>0.2.3.Final</version.org.hawkular.commons>
     <version.org.hawkular.cmdgw>0.10.4.Final</version.org.hawkular.cmdgw>
     <version.org.hawkular.metrics>0.9.0.Final</version.org.hawkular.metrics>
-    <version.org.hawkular.inventory>0.10.0.Final</version.org.hawkular.inventory>
+    <version.org.hawkular.inventory>0.10.1.Final</version.org.hawkular.inventory>
     <version.org.keycloak>1.6.1.Final</version.org.keycloak>
     <version.org.testng>6.5.2</version.org.testng>
   </properties>


### PR DESCRIPTION
This is to pull the correct version of `hawkular-commons` and other components.