### PR TITLE
UI fixes for M8

### DIFF
--- a/console/src/main/scripts/plugins/directives/subtab/html/subtab.html
+++ b/console/src/main/scripts/plugins/directives/subtab/html/subtab.html
@@ -34,7 +34,7 @@
       </div>
     </div>
     <div class="hk-heading">
-      <h1 ng-init="isAppServerPage() ? getAppServerFromId(hkParams.resourceId) : getUrlFromId(hkParams.resourceId)">{{resourceName}}</h1>
+      <h1 ng-init="isAppServerPage() ? getAppServerFromId(hkParams.resourceId) : (!isAlertsPage() && getUrlFromId(hkParams.resourceId))">{{resourceName}}</h1>
       <h1 ng-show="isAlertsPage()">Alert Center</h1>
     </div>
     <div ng-transclude></div>

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-overview.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-overview.html
@@ -24,7 +24,7 @@
     <!-- Server alerts -->
     <div class="col-lg-3 col-md-4">
       <hk-alert-info list="vm.alertList" limit="(vm.showAllAlerts ? 100000 : 3)"
-                     resource-id="vm.$routeParams.resourceId" title="Server">
+                     resource-id="vm.$routeParams.feedId + '/' + vm.$routeParams.resourceId" title="Server">
       </hk-alert-info>
     </div>
     <!-- //Server alerts -->

--- a/console/src/main/scripts/plugins/metrics/html/directives/alert-info.html
+++ b/console/src/main/scripts/plugins/metrics/html/directives/alert-info.html
@@ -1,27 +1,30 @@
 <div class="card-pf card-pf-utilization">
   <div class="card-pf-heading">
-  <p class="card-pf-heading-details hk-definitions-link">
-    <a href="#" ng-show="resourceId" ng-href="/hawkular-ui/alerts-center-triggers/{{resourceId}}">
-      <i class="fa fa-cog"></i>Definitions
-    </a>
-  </p>
-  <h2 class="card-pf-title">{{title}} Alerts <span class="label label-default" ng-show="list.length">{{list.length}}</span></h2>
-</div>
+    <p class="card-pf-heading-details hk-definitions-link">
+      <a href="#" ng-show="resourceId" ng-href="/hawkular-ui/alerts-center-triggers/{{resourceId}}">
+        <i class="fa fa-cog"></i>Definitions
+      </a>
+    </p>
+    <h2 class="card-pf-title">{{title}} Alerts
+      <span class="label label-default" ng-show="list.length">{{list.length}}</span>
+    </h2>
+  </div>
 
-<!-- No Alerts -->
-<div class="card-pf-body" ng-hide="list.length">
-  <div class="hk-box-v-item">
-    <div class="hk-display-table">
-      <div class="hk-icon-container">
-        <i class="fa fa-flag gray"></i>
-      </div>
-      <div class="hk-info-container">
-        <p class="hk-info-info">No Alerts.</p>
+  <!-- No Alerts -->
+  <div class="card-pf-body" ng-hide="list.length">
+    <div class="hk-box-v-item">
+      <div class="hk-display-table">
+        <div class="hk-icon-container">
+          <i class="fa fa-flag gray"></i>
+        </div>
+        <div class="hk-info-container">
+          <p class="hk-info-info">No Alerts.</p>
+        </div>
       </div>
     </div>
   </div>
-</div>
 
-<!-- Alerts exist -->
-<hk-alert-panel-list class="card-pf-body" hk-alert-list="list" ng-show="list.length"
-                      hk-limit="hkLimit"></hk-alert-panel-list>
+  <!-- Alerts exist -->
+  <hk-alert-panel-list class="card-pf-body" hk-alert-list="list" ng-show="list.length"
+                        hk-limit="hkLimit"></hk-alert-panel-list>
+</div>

--- a/console/src/main/scripts/plugins/metrics/ts/alerts.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alerts.ts
@@ -251,7 +251,7 @@ module HawkularMetrics {
 
   export class MetricsAlertController {
     public static  $inject = ['$scope', 'HawkularAlertsManager', 'ErrorsManager', 'NotificationsService', '$log', '$q',
-      '$rootScope', '$routeParams', '$modal', '$interval', 'HkHeaderParser'];
+      '$rootScope', '$routeParams', '$modal', '$interval', '$location', 'HkHeaderParser'];
 
     public alertList:any = [];
     public openSetup:any;
@@ -275,6 +275,7 @@ module HawkularMetrics {
                 private $routeParams:any,
                 private $modal:any,
                 private $interval:ng.IIntervalService,
+                private $location:ng.ILocationService,
                 private HkHeaderParser:any) {
 
       this.$log.debug('querying data');
@@ -285,6 +286,7 @@ module HawkularMetrics {
       this.alertsTimeEnd = $routeParams.endTime ? $routeParams.endTime : (new Date()).getTime();
       this.alertsTimeStart = this.alertsTimeEnd - this.alertsTimeOffset;
       this.getAlerts();
+      $scope.$on('SwitchedPersona', () => $location.path('/hawkular-ui/url/url-list'));
       this.autoRefresh(20);
     }
 

--- a/console/src/main/scripts/plugins/metrics/ts/alertsCenterDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alertsCenterDetails.ts
@@ -109,8 +109,6 @@ module HawkularMetrics {
     }
 
     public save(): void {
-      console.log('this.status: ' + this.status);
-      console.log('this.detailAlert.status: ' + this.detailAlert.status);
       if (this.status === this.detailAlert.status) {
         if (this.comments && this.comments.length > 0) {
           this.notes();

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerOverviewDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerOverviewDetails.ts
@@ -187,7 +187,6 @@ module HawkularMetrics {
             let latestData = _.last(resource);
             resourceData['activeWebSessions']['graph'] =
               MetricsService.formatBucketedChartOutput(resource, AppServerJvmDetailsController.BYTES2MB);
-            console.log(latestData['avg'], 'shdfsdkf');
             resourceData['activeWebSessions']['last'] = +latestData['avg'].toFixed(2);
           }
         })

--- a/console/src/main/scripts/plugins/metrics/ts/directives/fileReadDirective.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/fileReadDirective.ts
@@ -42,7 +42,6 @@ module HawkularMetrics {
             console.error('Error occurred in fileread directive: '+error);
           };
 
-          console.log(`Reading file: ${theFile.name} to deploy. Size: ${theFile.size}`);
           reader.readAsArrayBuffer(theFile);
         });
       }

--- a/console/src/main/scripts/plugins/metrics/ts/urlAvailabilityDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/urlAvailabilityDetails.ts
@@ -36,7 +36,7 @@ module HawkularMetrics {
 
   export class MetricsAvailabilityController {
     /// for minification only
-    public static  $inject = ['$scope', '$rootScope', '$interval', '$window', '$log', 'HawkularMetric',
+    public static  $inject = ['$scope', '$rootScope', '$interval', '$window', '$log', '$location', 'HawkularMetric',
       'MetricsService', '$routeParams', '$filter', '$moment', 'HawkularAlertsManager',
       'ErrorsManager', '$q', 'NotificationsService'];
 
@@ -60,6 +60,7 @@ module HawkularMetrics {
                 private $interval:ng.IIntervalService,
                 private $window:any,
                 private $log:ng.ILogService,
+                private $location:ng.ILocationService,
                 private HawkularMetric:any,
                 private MetricsService:any,
                 private $routeParams:any,
@@ -93,6 +94,7 @@ module HawkularMetrics {
           }
         });
       }
+      $scope.$on('SwitchedPersona', () => $location.path('/hawkular-ui/url/url-list'));
       this.autoRefreshAvailability(20);
 
       $scope.$on(EventNames.REFRESH_AVAIL_CHART, (/*event*/) => {

--- a/console/src/main/scripts/plugins/metrics/ts/urlResponseTimeDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/urlResponseTimeDetails.ts
@@ -24,7 +24,7 @@ module HawkularMetrics {
 
   export class MetricsViewController {
     /// for minification only
-    public static  $inject = ['$scope', '$rootScope', '$interval', '$log',
+    public static  $inject = ['$scope', '$rootScope', '$interval', '$log', '$location',
       '$routeParams', 'HawkularAlertsManager', 'ErrorsManager', '$q', 'NotificationsService', 'MetricsService'];
 
     private bucketedDataPoints:IChartDataPoint[] = [];
@@ -45,6 +45,7 @@ module HawkularMetrics {
                 private $rootScope:IHawkularRootScope,
                 private $interval:ng.IIntervalService,
                 private $log:ng.ILogService,
+                private $location:ng.ILocationService,
                 private $routeParams:any,
                 private HawkularAlertsManager:IHawkularAlertsManager,
                 private ErrorsManager:IErrorsManager,
@@ -80,6 +81,7 @@ module HawkularMetrics {
           }
         });
       }
+      $scope.$on('SwitchedPersona', () => $location.path('/hawkular-ui/url/url-list'));
       this.autoRefresh(20);
     }
 


### PR DESCRIPTION
- Remove useless, error throwing resource query on alert center pages;
- Fix links to Trigger definitions on Overview screen;
- Fix HTML (missing closing div) on alert-info directive;
- HAWKULAR-742 : Handle switch persona at URL details pages;
- Cleanup some console.log messages;