### PR TITLE
Hawkular-887 NaN alert values

### DIFF
--- a/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
@@ -363,12 +363,12 @@ module HawkularMetrics {
                   }
                 }
 
-                if ( evalItem.rate ) {
+                if ( undefined != evalItem.rate ) {
                   // handle rate conditions
                   sum += evalItem.rate;
                 } else {
-                  // handle compare conditions
-                  sum += ( evalItem.value ? evalItem.value : evalItem.value1 );
+                  // handle 'value' conditions and also compare conditions ('value1')
+                  sum += ( ( undefined != evalItem.value ) ? evalItem.value : evalItem.value1 );
                 }
                 count++;
               }


### PR DESCRIPTION
The fix for this may also improve accuracy for non-NaN values because we
weren't handling 0 values correctly.