### PR TITLE
Fixing the 'refname abcdef is ambiguous' issue when building the alerts with srcdep plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <version.gnu.getopt>1.0.13</version.gnu.getopt>
     <version.org.hawkular.accounts>1.1.4.Final</version.org.hawkular.accounts>
     <version.org.hawkular.agent>0.14.0.Final</version.org.hawkular.agent>
-    <version.org.hawkular.alerts>0.8.0.Final-SRC-revision-d105e2ba1ee28eb19f4573aa50065468d2bdaaa2</version.org.hawkular.alerts>
+    <version.org.hawkular.alerts>0.8.0.Final-SRC-tag-WF9</version.org.hawkular.alerts>
     <version.org.hawkular.bus>0.7.3.Final</version.org.hawkular.bus>
     <version.org.hawkular.commons>0.2.5.Final</version.org.hawkular.commons>
     <version.org.hawkular.cmdgw>0.10.5.Final</version.org.hawkular.cmdgw>


### PR DESCRIPTION
I was able to manually replicate by:
cloning the repo and running:
```bash
git pull https://github.com/hawkular/hawkular-alerts.git d105e2ba1ee28eb19f4573aa50065468d2bdaaa2:d105e2ba1ee28eb19f4573aa50065468d2bdaaa2
```

```bash
    [ERROR] Cloning into '/home/jkremser/.m2/repository/../dependency-sources/alerts'...
    From https://github.com/hawkular/hawkular-alerts
     * [new ref]         d105e2ba1ee28eb19f4573aa50065468d2bdaaa2 -> d105e2ba1ee28eb19f4573aa50065468d2bdaaa2
    warning: refname 'd105e2ba1ee28eb19f4573aa50065468d2bdaaa2' is ambiguous.
    Git normally never creates a ref that ends with 40 hex characters
    because it will be ignored when you just specify 40-hex. These refs
    may be created by mistake. For example,
   
      git checkout -b $br $(git rev-parse ...)
   
    where "$br" is somehow empty and a 40-hex ref is created. Please
    examine these refs and maybe delete them. Turn this message off by
    running "git config advice.objectNameWarning false"
```