### PR TITLE
Enabling the end-to-end integration test.

### DIFF
--- a/modules/end-to-end-test/pom.xml
+++ b/modules/end-to-end-test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");
@@ -227,6 +227,13 @@
                       <groupId>org.hawkular.inventory</groupId>
                       <artifactId>hawkular-inventory-itest</artifactId>
                       <version>${version.org.hawkular.inventory}</version>
+                      <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                    </artifactItem>
+
+                    <artifactItem>
+                      <groupId>org.hawkular</groupId>
+                      <artifactId>hawkular-end-to-end-tests</artifactId>
+                      <version>${project.version}</version>
                       <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                     </artifactItem>
                   </artifactItems>


### PR DESCRIPTION
Currently the only itests that are being run during the travis build are the ones for the inventory. This PR enables the itests also for the end-to-end test (this guy: http://git.io/vuzjw)