### PR TITLE
HAWKULAR-911 - Pinger error when adding a URL

### DIFF
--- a/modules/pinger/src/main/java/org/hawkular/component/pinger/Pinger.java
+++ b/modules/pinger/src/main/java/org/hawkular/component/pinger/Pinger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -62,11 +62,16 @@ public class Pinger {
     /** A key to use when storing and retrieving remote IP address from and to {@link HttpContext} */
     static final String REMOTE_ADDRESS_ATTRIBUTE = Pinger.class.getPackage().getName() + ".remoteAddress";
 
-    /** A custom connnection manager used by this pinger */
+    /**
+     * A custom connection manager used by this pinger
+     */
     private final HttpClientConnectionManager connectionManager;
 
+    private final CloseableHttpClient client;
+
     public Pinger() throws Exception {
-        connectionManager = createConnectionManager();
+        this.connectionManager = createConnectionManager();
+        this.client = HttpClientBuilder.create().setConnectionManager(connectionManager).build();
     }
 
     /**
@@ -124,7 +129,7 @@ public class Pinger {
         Log.LOG.debugf("About to ping %s", destination.getUrl());
         HttpUriRequest request = RequestBuilder.create(destination.getMethod()).setUri(destination.getUrl()).build();
 
-        try (CloseableHttpClient client = HttpClientBuilder.create().setConnectionManager(connectionManager).build()) {
+        try {
             long start = System.currentTimeMillis();
             HttpClientContext context = HttpClientContext.create();
             try (CloseableHttpResponse httpResponse = client.execute(request, context)) {


### PR DESCRIPTION
Each time the `ping()` method was invoked, it created a new client within the try-with-resource block... it implements the closeable so it also closed the client and client closes the connection pool of the `PoolingHttpClientConnectionManager`

The issue happened if 2 pings were done in parallel. 2 http clients were created, but they had 1 shared connection pool. Once the first client finished his work, it closed the connection pool and the 2nd client failed with the exception.

Solution is to recycle the Http client and close the connection (using the try-with-resource) idiom. Other option would be make the ping method synchronized (or some it's part), but this should be faster.

Note to myself: migrate to [okhttp](https://github.com/square/okhttp) and use the async approach, currently the http request is blocking and once it arrives the future object is created with the response => doesn't make any sense to me.