### PR TITLE
hot-fixing the install agent page 

### DIFF
--- a/console/src/main/scripts/bower.json
+++ b/console/src/main/scripts/bower.json
@@ -24,7 +24,7 @@
     "angular-toastr": "1.6.0",
     "animate.css": "3.0.0",
     "ngInfiniteScroll": "1.2.1",
-    "hawkular-charts": "hawkular/hawkular-charts#6610b0d",
+    "hawkular-charts": "hawkular/hawkular-charts#6610b0d82706518b22c5f89c3c6e87a0fd22ceeb",
     "hawkular-ui-services": "0.8.21",
     "hawtio-core-navigation": "2.0.51",
     "hawtio-core": "2.0.18",
@@ -37,8 +37,7 @@
     "patternfly": "2.7.0",
     "keycloak": "1.3.1",
     "angular-wizard": "0.5.5",
-    "ng-clip": "0.2.6",
-    "zeroclipboard": "2.2.0"
+    "angular-clipboard": "1.3.0"
   },
   "devDependencies": {
     "hawtio-core-dts": "2.0.18"

--- a/console/src/main/scripts/plugins/metrics/html/agent-installer.html
+++ b/console/src/main/scripts/plugins/metrics/html/agent-installer.html
@@ -12,7 +12,25 @@
 
               <form class="form-horizontal">
                 <fieldset>
-                  <legend>Required</legend>
+                  <legend>Optional
+                    <a class="hk-btn-icon" tabindex="-1" role="button" popover-append-to-body="true"
+                    popover-placement="top" popover-trigger="mouseover mouseout"
+                    popover="Neither of those fields are required. You can provide or override the parameters on the command line when running the jar file."><i class="fa fa-info-circle"></i></a></legend>
+                    <div class="form-group">
+                    <div class="row">
+                      <label class="col-sm-3 control-label" for="server-name">Server Name
+                        <a class="hk-btn-icon" tabindex="-1" role="button" popover-append-to-body="true"
+                           popover-placement="top" popover-trigger="mouseover mouseout"
+                           popover="The agent will use this name to refer to the server where it is deployed and locally managing.">
+                          <i class="fa fa-info-circle"></i></a>
+                      </label>
+                      <div class="col-sm-5">
+                        <div class="hk-input-text">
+                          <input ng-model="aic.serverName" class="form-control" id="server-name" hk-autofocus/>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                   <div class="form-group">
                     <div class="row">
                       <label class="col-sm-3 control-label" for="wildfly-home">Wildfly Home
@@ -24,28 +42,8 @@
                       </label>
                       <div class="col-sm-5">
                         <div class="hk-input-text">
-                          <input class="form-control" ng-model="aic.wildflyHome" id="wildfly-home" required hk-autofocus
+                          <input class="form-control" ng-model="aic.wildflyHome" id="wildfly-home" hk-autofocus
                                  placeholder="Copy&paste here the path of the Wildfly server"/>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </fieldset>
-
-                <fieldset>
-                  <legend>Optional</legend>
-                  <div class="form-group">
-                    <div class="row">
-                      <label class="col-sm-3 control-label" for="module-zip">Module zip
-                        <a class="hk-btn-icon" tabindex="-1" role="button" popover-append-to-body="true"
-                           popover-placement="top" popover-trigger="mouseover mouseout"
-                           popover="Path to non-default zip file with agent module.
-                            This way you can for instance deploy different version of the agent.">
-                          <i class="fa fa-info-circle"></i></a>
-                      </label>
-                      <div class="col-sm-5">
-                        <div class="hk-input-text">
-                          <input ng-model="aic.moduleZip" class="form-control" id="module-zip"/>
                         </div>
                       </div>
                     </div>
@@ -83,23 +81,25 @@
                     </div>
                   </div>
                   <div class="hk-form-actions-separator text-right">
+                  <div class="col-md-8"><i>
+                  Pro tip: rather than using the username password, it's better to generate token <a href="/hawkular-ui/tokens">here</a> and use it with <code>--security-key</code> <code>--security-code</code> when running the jar installer.
+                  </i></div><br/>
                     <button type="button" class="btn btn-primary" ng-click="aic.download()"
                             ng-disabled="!aic.requiredFieldsFilled(hawkularServerUrl, wildflyHome)">
                       Download Installer
                     </button>
                   </div>
                 </fieldset>
-
                 <div class="code-snippet" ng-show="aic.codeSnippetShown">
                   To install the wildfly agent, run following command:
-                  <!--
-                  <div class="zero-clipboard" auto-hide-on-no-flash="true">
-                    <span class="btn-clipboard">
-                      Copy
-                    </span>
-                  </div>-->
+                  <div clipboard class="clipboard" on-copied="aic.copySuccess()" on-error="aic.copyFail(err)"
+                     text="aic.snippetToCopy">
+                     <span class="btn-clipboard" popover-append-to-body="true"
+                          popover-placement="top" popover-trigger="mouseover mouseout"
+                          popover="Copy to clipboard.">Copy</span>
+                  </div>
                   <div class="highlight">
-                    <pre>$ java -jar hawkular-wildfly-agent-installer-0.13.1.Final.jar</pre>
+                    <pre>$ java -jar hawkular-wildfly-agent-installer.jar</pre>
                   </div>
                 </div>
               </form>

--- a/console/src/main/scripts/plugins/metrics/less/metrics.less
+++ b/console/src/main/scripts/plugins/metrics/less/metrics.less
@@ -2720,6 +2720,7 @@ section {
 
   .btn-clipboard {
     position: absolute;
+    cursor: pointer;
     top: 0;
     right: 0;
     z-index: 10;
@@ -2732,7 +2733,7 @@ section {
     border-radius: 0 4px 0 4px;
   }
 
-  .zero-clipboard {
+  .clipboard {
     position: relative;
     display: none;
   }
@@ -2742,10 +2743,8 @@ section {
   }
 
   @media (min-width: 768px) {
-    .zero-clipboard {
+    .clipboard {
       display: block;
-      position: relative;
-
     }
   }
 }

--- a/console/src/main/scripts/plugins/metrics/ts/agentInstaller.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/agentInstaller.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,12 +25,13 @@ module HawkularMetrics {
     private httpUriPart = 'http://';
     private hawkularServerUrl: string;
     private wildflyHome: string;
-    private moduleZip: string;
+    private serverName: string;
 
     private username: string;
     private password: string;
 
     private codeSnippetShown: boolean;
+    private snippetToCopy: string = 'java -jar hawkular-wildfly-agent-installer.jar';
 
     constructor(private $location:ng.ILocationService,
                 private $scope:any,
@@ -43,24 +44,29 @@ module HawkularMetrics {
     }
 
     public requiredFieldsFilled(hawkularServerUrl: string, wildflyHome: string): boolean {
-      //return this.hawkularServerUrl !== undefined
-      //  && ((this.hawkularServerUrl.slice(0, 7) === 'http://' && this.hawkularServerUrl.length > 7)
-      //      || (this.hawkularServerUrl.slice(0, 8) === 'https://' && this.hawkularServerUrl.length > 8)) &&
-        return this.wildflyHome !== undefined && this.wildflyHome.length > 2;
+        return true;
     }
 
-    public getTextToCopy(): string {
-      return 'java -jar hawkular-wildfly-agent-installer-0.13.1.Final.jar';
+    public copySuccess(): void {
+      console.log('copied to clipboard');
+
+    }
+
+    public copyFail(err): void {
+      console.error('copy error', err);
     }
 
     public download(): void {
-      var newPath = '/hawkular/wildfly-agent/download?installer=true&wildfly-home='
-        + encodeURIComponent(this.wildflyHome);
+      let newPath = '/hawkular/wildfly-agent/installer?';
+
+      if (this.wildflyHome) {
+        newPath += '&target-location=' + encodeURIComponent(this.wildflyHome);
+      }
       if (this.hawkularServerUrl) {
         newPath += '&hawkular-server-url=' + encodeURIComponent(this.hawkularServerUrl);
       }
-      if (this.moduleZip) {
-        newPath += '&module-zip=' + encodeURIComponent(this.moduleZip);
+      if (this.serverName) {
+        newPath += '&managed-server-name=' + encodeURIComponent(this.serverName);
       }
       if (this.username) {
         newPath += '&username=' + encodeURIComponent(this.username);
@@ -74,12 +80,6 @@ module HawkularMetrics {
     }
 
   }
-  _module.config(['ngClipProvider', (ngClipProvider) => {
-    ngClipProvider.setConfig({
-      zIndex: 50
-    });
-  }]);
-
   _module.controller('AgentInstallerController', AgentInstallerController);
 
 }

--- a/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsPlugin.ts
@@ -22,7 +22,7 @@ module HawkularMetrics {
 
   export let _module = angular.module(HawkularMetrics.pluginName, ['ngResource', 'ngAnimate', 'ui.select',
     'hawkular.services', 'ui.bootstrap', 'topbar', 'patternfly.select', 'angular-momentjs', 'angular-md5', 'toastr',
-    'infinite-scroll', 'mgo-angular-wizard', 'hawkular.charts', 'ngClipboard', 'patternfly.filters',
+    'infinite-scroll', 'mgo-angular-wizard', 'hawkular.charts', 'angular-clipboard', 'patternfly.filters',
     'patternfly.charts']);
 
   _module.config(['$compileProvider', function ($compileProvider) {


### PR DESCRIPTION
Currently it's broken and it's downloading the module zip file instead of the installer jar, because the server-side was slightly changed.

This change:
* changes the url that was changed in the servlet (`/hawkular/wildfly-agent/download?installer=true` -> `/hawkular/wildfly-agent/installer`)
* removes the 'Required' form section and makes everything optional
* adds the copy button that will copy the `java -jar foo..` command into user's clipboard
* removes the version information that is no longer valid

NOTE1: this page will be probably different in the future this is a hot fix to have something working for the next alpha

NOTE2: I wasn't able to make the [zeroclipboard](https://github.com/zeroclipboard/zeroclipboard) + [ngClip](https://github.com/asafdav/ng-clip) working when [this](https://git.io/vzcDz) was set to false, so I used the [angular-clipboard](https://github.com/omichelsen/angular-clipboard). ZeroClipboard depends on Flash but it's pretty much the current standard (used by GitHub for instance) and works with old browsers. The angular-clipboard is pretty new and uses the new features in modern browsers, so it doesn't require the Flash, but quite a new browser (Chrome 43+, Firefox 41+, Opera 29+ and IE10+)