### PR TITLE
Update the copyright to the latest versions so we are not fighting on…

### DIFF
--- a/console/src/main/scripts/plugins/accounts/includes.ts
+++ b/console/src/main/scripts/plugins/accounts/includes.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/accounts/ts/invitation.ts
+++ b/console/src/main/scripts/plugins/accounts/ts/invitation.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/accounts/ts/persona.ts
+++ b/console/src/main/scripts/plugins/accounts/ts/persona.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/accounts/ts/settings.ts
+++ b/console/src/main/scripts/plugins/accounts/ts/settings.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/emails/ts/emailsDirective.ts
+++ b/console/src/main/scripts/plugins/directives/emails/ts/emailsDirective.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/emails/ts/emailsGlobals.ts
+++ b/console/src/main/scripts/plugins/directives/emails/ts/emailsGlobals.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/emails/ts/emailsPlugin.ts
+++ b/console/src/main/scripts/plugins/directives/emails/ts/emailsPlugin.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/includes.ts
+++ b/console/src/main/scripts/plugins/directives/includes.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/subtab/ts/subtabGlobals.ts
+++ b/console/src/main/scripts/plugins/directives/subtab/ts/subtabGlobals.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/subtab/ts/subtabPlugin.ts
+++ b/console/src/main/scripts/plugins/directives/subtab/ts/subtabPlugin.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/topbar/ts/topbarDirective.ts
+++ b/console/src/main/scripts/plugins/directives/topbar/ts/topbarDirective.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/topbar/ts/topbarGlobals.ts
+++ b/console/src/main/scripts/plugins/directives/topbar/ts/topbarGlobals.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/topbar/ts/topbarPlugin.ts
+++ b/console/src/main/scripts/plugins/directives/topbar/ts/topbarPlugin.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/topbar/ts/topbarServices.ts
+++ b/console/src/main/scripts/plugins/directives/topbar/ts/topbarServices.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/includes.ts
+++ b/console/src/main/scripts/plugins/metrics/includes.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/alertsCenterDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alertsCenterDetails.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/alertsCenterList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/alertsCenterList.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerAlertsDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerAlertsDetails.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJmsDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerJmsDetails.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerTransactionsDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerTransactionsDetails.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesDeleteDialog.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesDeleteDialog.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesDriverDeleteDialog.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesDriverDeleteDialog.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesEditDialog.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/modals/appServerDatasourcesEditDialog.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/appServerDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/appServerDetails.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/directives/alertSetupNotificationDirective.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/alertSetupNotificationDirective.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/directives/fileReadDirective.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/fileReadDirective.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/directives/filterDirective.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/filterDirective.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/directives/hkComponents.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/hkComponents.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/directives/overview/commonTasksDirective.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/overview/commonTasksDirective.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/directives/paginationDirectives.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/paginationDirectives.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/directives/validFileDirective.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/validFileDirective.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/filters/durationFilter.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/filters/durationFilter.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/filters/firstUpperFilter.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/filters/firstUpperFilter.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/filters/truncateFilter.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/filters/truncateFilter.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/globalController.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/globalController.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/metricsGlobals.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/metricsGlobals.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/alertsManager.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/services/errorsManager.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/errorsManager.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/services/metricsService.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/metricsService.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/services/notificationsService.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/notificationsService.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/services/paginationService.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/services/paginationService.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/triggers/eventTrigger.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/triggers/eventTrigger.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/metrics/ts/utility.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/utility.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/topology/directives/hawkularTopologyIcon.ts
+++ b/console/src/main/scripts/plugins/topology/directives/hawkularTopologyIcon.ts
@@ -1,5 +1,5 @@
 ///
-/// Copyright 2015 Red Hat, Inc. and/or its affiliates
+/// Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 /// and other contributors as indicated by the @author tags.
 ///
 /// Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
…e off license issues with license manager failing the builds.
Changed from 'Copyright 2015' to 'Copyright 2015-2016'