### PR TITLE
HAWKULAR-986 : Remove "Export JDR" button from App Server tabs template

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/app-details/app-server-details.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/app-server-details.html
@@ -13,18 +13,7 @@
 
   </hawkular-subtab>
 
-  <div ng-repeat="tab in tabs.availableTabs">{{tab.controller}}</div>
-
   <ng-include ng-repeat="tab in tabs.availableTabs" src="tab.src" ng-if="tabs.activeTab === tab.id"
               ng-controller="tab.controller"></ng-include>
-
-  <div ng-if="tabs.activeTab !== 'overview'">
-    <div class="hk-nav-tabs-container">
-      <button type="button" class="btn btn-primary" ng-click="tabs.requestExportJDR()"
-              ng-disabled="tabs.jdrGenerating">
-        Export JDR
-      </button>
-    </div>
-  </div>
 
 </div>


### PR DESCRIPTION
Since the server overview already has the operation in the proper place, removing the temporary solution.