### PR TITLE
Not using the hystrix command timeouts in i-tests that are run by travis

### DIFF
--- a/modules/end-to-end-test/pom.xml
+++ b/modules/end-to-end-test/pom.xml
@@ -175,6 +175,7 @@
                 <org.apache.commons.logging.simplelog.log.org.apache.http.wire>
                   ${http.log.wire}
                 </org.apache.commons.logging.simplelog.log.org.apache.http.wire>
+                <hystrix.command.default.execution.timeout.enabled>false</hystrix.command.default.execution.timeout.enabled>
               </systemPropertyVariables>
               <!--<argLine>-Xdebug -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y</argLine>-->
             </configuration>
@@ -225,7 +226,6 @@
                 <javaOpt>-Dhawkular.log.liquibase=${hawkular.log.liquibase}</javaOpt>
                 <javaOpt>-Dhawkular.log.ejb3=${hawkular.log.ejb3}</javaOpt>
                 <javaOpt>-Dhawkular.log.rewrite=${hawkular.log.rewrite}</javaOpt>
-                <javaOpt>-Dhawkular.log.rewrite=${hawkular.log.rewrite}</javaOpt>
                 <!--<javaOpt>-Xdebug</javaOpt>-->
                 <!--<javaOpt>-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y</javaOpt>-->
               </javaOpts>
@@ -272,13 +272,6 @@
                                           <version>${version.org.hawkular.inventory}</version>
                                           <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
                                         </artifactItem>-->
-                    <artifactItem>
-                      <groupId>org.hawkular</groupId>
-                      <artifactId>hawkular-end-to-end-tests</artifactId>
-                      <version>${project.version}</version>
-                      <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
-                    </artifactItem>
-
                     <artifactItem>
                       <groupId>org.hawkular</groupId>
                       <artifactId>hawkular-end-to-end-tests</artifactId>

--- a/modules/hawkular-api-parent/hawkular-rest-api/pom.xml
+++ b/modules/hawkular-api-parent/hawkular-rest-api/pom.xml
@@ -57,6 +57,11 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.14</version>
+    </dependency>
 <!--
     <dependency>
       <groupId>org.hawkular.inventory</groupId>
@@ -103,7 +108,8 @@
     <!-- RX -->
     <dependency>
       <groupId>com.netflix.hystrix</groupId>
-      <artifactId>hystrix-core</artifactId>
+      <artifactId>hystrix-metrics-event-stream</artifactId>
+      <version>1.4.10</version>
     </dependency>
 
     <dependency>

--- a/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/web.xml
+++ b/modules/hawkular-api-parent/hawkular-rest-api/src/main/webapp/WEB-INF/web.xml
@@ -54,6 +54,18 @@
     <role-name>admin</role-name>
   </security-role>
 
+  <!-- this servlet exposes the metrics from hystrix commands, see https://git.io/vgfJe -->
+  <servlet>
+    <description></description>
+    <display-name>HystrixMetricsStreamServlet</display-name>
+    <servlet-name>HystrixMetricsStreamServlet</servlet-name>
+    <servlet-class>com.netflix.hystrix.contrib.metrics.eventstream.HystrixMetricsStreamServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>HystrixMetricsStreamServlet</servlet-name>
+    <url-pattern>/hystrix.stream</url-pattern>
+  </servlet-mapping>
+
   <!-- this filter creates the hystrix context around each incoming request -->
   <filter>
     <display-name>HystrixRequestContextServletFilter</display-name>

--- a/modules/hawkular-api-parent/hawkular-rx/pom.xml
+++ b/modules/hawkular-api-parent/hawkular-rx/pom.xml
@@ -49,6 +49,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.14</version>
+    </dependency>
+
+
 <!--
     <dependency>
       <groupId>org.hawkular.inventory</groupId>

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/AbstractHttpCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/AbstractHttpCommand.java
@@ -26,7 +26,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.hawkular.rx.cdi.WithValues;
 
 import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixCommandProperties;
 import com.netflix.hystrix.HystrixObservableCommand;
 
 /**
@@ -35,14 +34,11 @@ import com.netflix.hystrix.HystrixObservableCommand;
 public abstract class AbstractHttpCommand<R> extends HystrixObservableCommand<R> {
 
     private AbstractHttpCommand() {
-        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("Other"))
-                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-                        .withExecutionTimeoutInMilliseconds(2500)));
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("Other")));
     }
 
     protected AbstractHttpCommand(HystrixCommandGroupKey group) {
-        super(Setter.withGroupKey(group).andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-                .withExecutionTimeoutInMilliseconds(2500)));
+        super(Setter.withGroupKey(group));
     }
 
     protected AbstractHttpCommand(Setter setter) {

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/CommandLogger.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/common/CommandLogger.java
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hawkular.rest;
 
+package org.hawkular.rx.commands.common;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -26,35 +26,35 @@ import org.jboss.logging.annotations.MessageLogger;
 
 /**
  * Logger definitions for Jboss Logging for the rest api
- * <p/>
- * Code range is 5500-5749
+ * <p>
+ * Code range is 5750-5999
  *
- * @author Heiko W. Rupp
+ * @author Jirka Kremser
  */
 @MessageLogger(projectCode = "HAWKULAR")
-public interface RestApiLogger extends BasicLogger {
+public interface CommandLogger extends BasicLogger {
 
-    RestApiLogger LOGGER = Logger.getMessageLogger(RestApiLogger.class, "org.hawkular.rest");
+    CommandLogger LOGGER = Logger.getMessageLogger(CommandLogger.class, "org.hawkular.rest.rx");
 
-    RestApiLogger REQUESTS_LOGGER = Logger
-            .getMessageLogger(RestApiLogger.class, "org.hawkular.rest.requests");
+    CommandLogger REQUESTS_LOGGER = Logger
+            .getMessageLogger(CommandLogger.class, "org.hawkular.rest.requests");
 
     @LogMessage(level = Logger.Level.INFO)
-    @Message(id = 5500, value = "Hawkular REST Api is starting...") void apiStarting();
+    @Message(id = 5750, value = "Hawkular REST Api is starting...") void apiStarting();
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 5501, value = "Something bad has happened") void warn(@Cause Throwable t);
+    @Message(id = 5751, value = "Something bad has happened") void warn(@Cause Throwable t);
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 5502, value = "Bus Integration initialization failed. Inventory will not notify about changes on " +
+    @Message(id = 5752, value = "Bus Integration initialization failed. Inventory will not notify about changes on " +
             "the Hawkular message bus. Cause: [%s]") void busInitializationFailed(String message);
 
     @LogMessage(level = Logger.Level.WARN)
-    @Message(id = 5503, value = "Security check failed on entity: [%s]") void securityCheckFailed(String entityId,
+    @Message(id = 5753, value = "Security check failed on entity: [%s]") void securityCheckFailed(String entityId,
                                                                                                   @Cause
                                                                                                   Throwable cause);
 
     @LogMessage(level = Logger.Level.DEBUG)
-    @Message(id = 5504, value = "Accepting:\nHTTP %s -> %s\n\nheaders:\n%s\npayload:\n%s\njavaMethod: %s\n")
+    @Message(id = 5754, value = "Accepting:\nHTTP %s -> %s\n\nheaders:\n%s\npayload:\n%s\njavaMethod: %s\n")
     void restCall(String method, String url, String headers, String jsonPayload, String javaMethod);
 }

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/CreateUrlCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/CreateUrlCommand.java
@@ -44,7 +44,6 @@ import org.hawkular.rx.httpclient.HttpClient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixCommandProperties;
 
 import rx.Observable;
 import rx.Subscriber;
@@ -94,9 +93,7 @@ public class CreateUrlCommand extends AbstractHttpCommand<String> {
 
     @Inject
     protected CreateUrlCommand(InjectionPoint ip) {
-        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("URL"))
-                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-                        .withExecutionTimeoutInMilliseconds(3500)));
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("URL")));
         initialize(ip);
     }
 
@@ -110,6 +107,7 @@ public class CreateUrlCommand extends AbstractHttpCommand<String> {
                     }
                     CreateResourceCommand createResourceCmd =
                             createResourceCommandInjector.select(Initialized.withValues(authToken, persona)).get();
+
 
                     String hashedUrl = md5Hash(url);
                     Resource.Blueprint urlBlueprint = Resource.Blueprint.builder()

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/DeleteUrlCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/hawkular/DeleteUrlCommand.java
@@ -113,8 +113,8 @@ public class DeleteUrlCommand extends AbstractHttpCommand<String> {
                     // make the first 2 calls in parallel and the third one after they finish
                     observeCmd1
                             .zipWith(observeCmd2, (first, second) -> new ImmutablePair(first, second))
-                            .flatMap((pair) -> observeDeleteResource).buffer(2).subscribe((aggregatedCmdResponse) -> {
-                        observer.onNext(aggregatedCmdResponse.get(1));
+                            .flatMap((pair) -> observeDeleteResource).subscribe((resourceDeletedResponse) -> {
+                        observer.onNext(resourceDeletedResponse);
                         observer.onCompleted();
                     });
 

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/CreateMetricCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/CreateMetricCommand.java
@@ -34,7 +34,6 @@ import org.hawkular.rx.httpclient.RestResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixCommandProperties;
 
 import rx.Observable;
 import rx.Subscriber;
@@ -74,9 +73,7 @@ public class CreateMetricCommand extends AbstractHttpCommand<String> {
 
     @Inject
     private CreateMetricCommand(InjectionPoint ip) {
-        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("inventory-metric"))
-                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-                        .withExecutionTimeoutInMilliseconds(1500)));
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("inventory-metric")));
         initialize(ip);
     }
 

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/CreateResourceCommand.java
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/java/org/hawkular/rx/commands/inventory/CreateResourceCommand.java
@@ -35,7 +35,6 @@ import org.hawkular.rx.httpclient.RestResponse;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixCommandProperties;
 
 import rx.Observable;
 import rx.Subscriber;
@@ -77,9 +76,7 @@ public class CreateResourceCommand extends AbstractHttpCommand<String> {
 
     @Inject
     private CreateResourceCommand(InjectionPoint ip) {
-        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("inventory-resource"))
-                .andCommandPropertiesDefaults(HystrixCommandProperties.Setter()
-                        .withExecutionTimeoutInMilliseconds(2500)));
+        super(Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey("inventory-resource")));
         initialize(ip);
     }
 

--- a/modules/hawkular-api-parent/hawkular-rx/src/main/resources/config.properties
+++ b/modules/hawkular-api-parent/hawkular-rx/src/main/resources/config.properties
@@ -1,0 +1,19 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#hystrix.command.default.execution.isolation.thread.timeoutInMilliseconds=5000
+hystrix.command.default.execution.timeout.enabled=true

--- a/modules/hawkular-api-parent/hawkular-rx/src/test/resources/config.properties
+++ b/modules/hawkular-api-parent/hawkular-rx/src/test/resources/config.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+# and other contributors as indicated by the @author tags.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+hystrix.command.default.execution.timeout.enabled=false


### PR DESCRIPTION
The timeouts are there for all the hystrix commands. Some commands are simple and some are compound and call multiple rest endpoints (`{Create|Delete}UrlCommand` performs 3 calls (2 in parallel, tough)). The timeouts can be tuned per command or globaly, or turned off. It's done via the [archaius](https://github.com/Netflix/archaius) config library, it supports sysprops, config files and also zookeeper, etcd and other backends with all the overriding logic.

I've already increased the timeout because I saw a failure in travis, but it's happening again so lets turn it off for the itests.

Second part is exposing the metrics from hystrix commands as an event stream - https://git.io/vgfJe
This should be available on `http://localhost:8080/hawkular/api/hystrix.stream` and it can be visualized by [hystrix-dashboard](https://github.com/Netflix/Hystrix/tree/master/hystrix-dashboard)