### PR TITLE
HAWKULAR-996 : Remove hk-alert-notification from URL details page

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/url-availability.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-availability.html
@@ -13,8 +13,6 @@
 
   <section id="hk-availability" class="hk-tab-content">
 
-    <hk-alert-notification></hk-alert-notification>
-
     <!-- Summary -->
     <div class="hk-info-top clearfix">
       <h3 class="pull-left">Availability Status</h3>

--- a/console/src/main/scripts/plugins/metrics/html/url-response-time.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-response-time.html
@@ -15,8 +15,6 @@
 
   <section class="hk-tab-content" id="hk-response-time">
 
-    <hk-alert-notification></hk-alert-notification>
-
     <!-- Summary -->
     <div class="hk-info-top clearfix">
       <h3 class="pull-left">Response Time Status</h3>

--- a/console/src/main/scripts/plugins/metrics/ts/directives/alertSetupNotificationDirective.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/alertSetupNotificationDirective.ts
@@ -23,7 +23,7 @@ module HawkularMetrics {
   class HkAlertNotification {
 
     public controller: ($scope: any) => void;
-    public templateUrl = 'plugins/metrics/html/alert-setup-notification.html';
+    public templateUrl = 'plugins/metrics/html/directives/alert-setup-notification.html';
     public replace = 'true';
 
     public static Factory() {


### PR DESCRIPTION
Also fix the path to the directive template.
It should evaluated if this directive, inline notification, is to be used. If not, remove it completely from alerts.