### PR TITLE
HAWKULAR-1009 : Adapt to metrics API change to percentiles

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/url-response-time.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-response-time.html
@@ -78,7 +78,7 @@
             <!-- HINT: colors for the chart can be changed in the hawkular-charts.css -->
             <hawkular-chart
               data="vm.chartData.dataPoints"
-              chart-type="hawkularmetric"
+              chart-type="line"
               alert-value="{{vm.threshold}}"
               use-zero-min-value="true"
               y-axis-units="Response Time (ms)"

--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerOverviewDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerOverviewDetails.ts
@@ -43,7 +43,7 @@ module HawkularMetrics {
     public date: Date;
     public min: any;
     public max: any;
-    public percentile95th: any;
+    public percentiles: IPercentile[];
     public median: any;
     public timestamp: number;
     public value: any;
@@ -55,7 +55,7 @@ module HawkularMetrics {
       this.timestamp = timestamp;
       this.min = value;
       this.max = value;
-      this.percentile95th = value;
+      this.percentiles = []; // FIXME: this should be revisited
       this.median = value;
       this.date = new Date(timestamp);
       this.value = value;

--- a/console/src/main/scripts/plugins/metrics/ts/urlList.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/urlList.ts
@@ -43,7 +43,7 @@ module HawkularMetrics {
     public date: Date;
     public min: number;
     public max: number;
-    public percentile95th: number;
+    public percentiles: IPercentile[];
     public median: number;
     public timestamp: number;
     public value: number;
@@ -56,7 +56,7 @@ module HawkularMetrics {
       this.timestamp = timestamp;
       this.min = value;
       this.max = value;
-      this.percentile95th = value;
+      this.percentiles = []; // FIXME: this should be revisited
       this.median = value;
       this.date = new Date(timestamp);
       this.value = value;

--- a/console/src/main/scripts/plugins/metrics/ts/urlResponseTimeDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/urlResponseTimeDetails.ts
@@ -155,7 +155,6 @@ module HawkularMetrics {
     public refreshSummaryData(metricId: MetricId,
       startTime?: TimestampInMillis,
       endTime?: TimestampInMillis): void {
-      let dataPoints: IChartDataPoint[];
 
       // calling refreshChartData without params use the model values
       if (!endTime) {
@@ -168,14 +167,13 @@ module HawkularMetrics {
       if (metricId) {
 
         this.MetricsService.retrieveGaugeMetrics(this.$rootScope.currentPersona.id,
-          metricId, startTime, endTime, 1)
+          metricId, startTime, endTime, 1, {percentiles: '95'})
           .then((response) => {
 
-            dataPoints = MetricsService.formatBucketedChartOutput(response);
-
-            this.median = Math.round(_.last(dataPoints).median);
-            this.percentile95th = Math.round(_.last(dataPoints).percentile95th);
-            this.average = Math.round(_.last(dataPoints).avg);
+            let data: any = response[0];
+            this.median = Math.round(data.median);
+            this.percentile95th = Math.round(data.percentiles[0].value);
+            this.average = Math.round(data.avg);
 
           }, (error) => {
             this.NotificationsService.error('Error Loading Chart Data: ' + error);


### PR DESCRIPTION
Metrics have changed the way percentiles are requested and the way they
are sent. This was causing URL Percentil 95th to be shown as 0.

Also change chart type for RT from deprecated "hawkularmetric" to "line"