### PR TITLE
HAWKULAR-1019 : Fix sparkline chart when c3-danger class is applied

### DIFF
--- a/console/src/main/scripts/plugins/metrics/less/metrics.less
+++ b/console/src/main/scripts/plugins/metrics/less/metrics.less
@@ -33,10 +33,13 @@ body {
 }
 
 .c3-danger {
-  path {
+  path.sparklineArea {
     stroke: @brand-danger;
     fill: @brand-danger;
-    fill-opacity: .4;
+    fill-opacity: .2;
+  }
+  path.sparklineLine {
+    stroke: @brand-danger;
   }
 }
 


### PR DESCRIPTION
The fill should only be applied to sparklineArea and not to sparklineLine