### PR TITLE
Move back to Angular 1.4.4 from Angular 1.4.8 to resolve bower confli…

### DIFF
--- a/.travis.maven.settings.xml
+++ b/.travis.maven.settings.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/java/org/hawkular/console/configuration/KeycloakConfigurationServlet.java
+++ b/console/src/main/java/org/hawkular/console/configuration/KeycloakConfigurationServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/java/org/hawkular/console/configuration/PushStateConfigurationProvider.java
+++ b/console/src/main/java/org/hawkular/console/configuration/PushStateConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/.editorconfig
+++ b/console/src/main/scripts/.editorconfig
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Red Hat, Inc. and/or its affiliates
+# Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
 # and other contributors as indicated by the @author tags.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/bower.json
+++ b/console/src/main/scripts/bower.json
@@ -43,7 +43,7 @@
   },
   "resolutions": {
     "lodash": "~3.2.0",
-    "angular": "~1.4.9",
+    "angular": "1.4.4",
     "keycloak": "1.3.1",
     "d3": "3.5.5"
   }

--- a/console/src/main/scripts/plugins/directives/subtab/less/subtab.less
+++ b/console/src/main/scripts/plugins/directives/subtab/less/subtab.less
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/scripts/plugins/directives/topbar/less/topbar.less
+++ b/console/src/main/scripts/plugins/directives/topbar/less/topbar.less
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/console/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/console/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/console/src/main/webapp/WEB-INF/web.xml
+++ b/console/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/hawkular-wildfly-agent-download/src/main/java/org/hawkular/component/wildflymonitor/WildFlyAgentServlet.java
+++ b/modules/hawkular-wildfly-agent-download/src/main/java/org/hawkular/component/wildflymonitor/WildFlyAgentServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates
+ * Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
  * and other contributors as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/hawkular-wildfly-agent-download/src/main/webapp/WEB-INF/beans.xml
+++ b/modules/hawkular-wildfly-agent-download/src/main/webapp/WEB-INF/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/hawkular-wildfly-agent-download/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/modules/hawkular-wildfly-agent-download/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/hawkular-wildfly-agent-download/src/main/webapp/WEB-INF/jboss-ejb3.xml
+++ b/modules/hawkular-wildfly-agent-download/src/main/webapp/WEB-INF/jboss-ejb3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");

--- a/modules/hawkular-wildfly-agent-download/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/modules/hawkular-wildfly-agent-download/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2015 Red Hat, Inc. and/or its affiliates
+    Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
     and other contributors as indicated by the @author tags.
 
     Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
…ct resolution. Our options are 1.4.4 or 1.5.0. So 1.4.4 was chosen.

bower angular                        resolution Unsuitable resolution declared for angular: 1.4.8

Unable to find a suitable version for angular, please choose one:
    1) angular#1.3.20 which resolved to 1.3.20 and is required by angular-route#1.3.20, angular-sanitize#1.3.20
    2) angular#~1.3.5 which resolved to 1.3.20 and is required by hawtio-core#2.0.30
    3) angular#1.4.4 which resolved to 1.4.4 and is required by angular-animate#1.4.4
    4) angular#* which resolved to 1.5.0 and is required by angular-clipboard#1.3.0, angular-md5#0.1.10, angular-momentjs#0.2.2, angular-wizard#0.6.1
    5) angular#>=1.3.0 which resolved to 1.5.0 and is required by angular-bootstrap#0.13.4, angular-toastr#1.6.0
    6) angular#^1.2.16 which resolved to 1.5.0 and is required by angular-scroll#0.6.5
    7) angular#^1.3.0 which resolved to 1.5.0 and is required by hawkular-charts#9bfefa9
    8) angular#1.5.0 which resolved to 1.5.0 and is required by angular-resource#1.5.0
    9) angular#>= 1.2.0 which resolved to 1.5.0 and is required by ng-idle#1.0.4
    10) angular#>=1.2.0 which resolved to 1.5.0 and is required by ngInfiniteScroll#1.2.1
    11) angular#>=1.2.18 which resolved to 1.5.0 and is required by angular-ui-select#0.11.2
    12) angular#^1.3.5 which resolved to 1.5.0 and is required by hawkular-ui-services#0.8.23