### PR TITLE
HAWKULAR-1053 change loading of recursive children and metrics

### DIFF
--- a/console/src/main/scripts/plugins/metrics/html/directives/explorer/side-filter-container.html
+++ b/console/src/main/scripts/plugins/metrics/html/directives/explorer/side-filter-container.html
@@ -18,7 +18,7 @@
     <div class="card-pf">
       <h3>Resource children tree</h3>
       <div ng-if="$ctrl.childrenTree.length !== 0">
-        <hk-boot-nav-tree tree-data="$ctrl.childrenTree" on-node-selected="$ctrl.onBranchSelect(branch)"></hk-boot-nav-tree>
+        <hk-boot-nav-tree tree-data="$ctrl.childrenTree" on-node-selected="$ctrl.onLoadMetrics(resource)"></hk-boot-nav-tree>
       </div>
     </div>
   </div>

--- a/console/src/main/scripts/plugins/metrics/html/explorer.html
+++ b/console/src/main/scripts/plugins/metrics/html/explorer.html
@@ -1,5 +1,5 @@
-<div ng-controller="ExplorerController as exc">
-  <div class="hk-sidebar hk-explorer-sidebar">
+<div ng-controller="InventoryExplorerController as exc">
+  <div class="hk-sidebar hk-explorer-sidebar" >
     <hk-side-filter-container selected-feed="exc.selectedFeed"
                               selected-resource="exc.selectedResource"
                               load-metrics="exc.getMetrics(resource)"></hk-side-filter-container>
@@ -14,13 +14,13 @@
                   <div class="col-md-4">
                      <div class="card-pf">
                       <h3>Selected Feed</h3>
-                      <div class="card-pf-title">{{exc.selectedFeed.id}}</div>
+                      <span class="hk-selected-resource">{{exc.selectedFeed.id}}</span>
                      </div>
                   </div>
                   <div class="col-md-4">
                     <div class="card-pf">
                       <h3>Selected Resource</h3>
-                      <div class="card-pf-title">{{exc.selectedResource.id}}</div>
+                      <span class="hk-selected-resource">{{exc.selectedResource.id}}</span>
                     </div>
                   </div>
                   <div class="col-md-4">
@@ -35,7 +35,7 @@
                               </li>
                           </ul>
                       </div>
-                      <div class="card-pf-title">{{exc.selectedMetric.name}}</div>
+                      <span class="hk-selected-resource">{{exc.selectedMetric.name}}</span>
                     </div>
                   </div>
               </div>

--- a/console/src/main/scripts/plugins/metrics/less/metrics.less
+++ b/console/src/main/scripts/plugins/metrics/less/metrics.less
@@ -348,6 +348,10 @@ a:hover {
 
 .row-cards-pf {
   clear: both;
+
+  .card-pf .hk-selected-resource {
+    word-break: break-all;
+  }
 }
 
 .card-pf-title {
@@ -2600,7 +2604,7 @@ body {
     background: none;
 
     .card-pf {
-      overflow: auto;
+      word-break: break-all;
     }
   }
 

--- a/console/src/main/scripts/plugins/metrics/ts/directives/navTree.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/directives/navTree.ts
@@ -21,20 +21,25 @@
 module HawkularMetrics {
   export class HkNavTreeDirective {
     public link = (scope: any, element: ng.IAugmentedJQuery, attrs: ng.IAttributes) => {
-      angular.element(document).ready(function () {
-        scope.$slider = $(element)['treeview']({
-          collapseIcon: 'fa fa-angle-down',
-          data: scope.treeData,
-          expandIcon: 'fa fa-angle-right',
-          emptyIcon: 'fa fa-file',
-          showIcon: false,
-          levels: 1,
-          onNodeSelected: (event, data) => {
-            scope.onNodeSelected({branch: data});
-          },
-          showBorder: false
-        });
+      scope.$watch('treeData',() => {
+        scope.onRefresh();
       });
+      scope.onRefresh = () => {
+        angular.element(document).ready(function () {
+          scope.$slider = $(element)['treeview']({
+            collapseIcon: 'fa fa-angle-down',
+            data: scope.treeData,
+            expandIcon: 'fa fa-angle-right',
+            emptyIcon: 'fa fa-file',
+            showIcon: false,
+            levels: 1,
+            onNodeSelected: (event, data) => {
+              scope.onNodeSelected({resource: data});
+            },
+            showBorder: false
+          });
+        });
+      };
     };
     public template = '<div></div>';
     public replace = 'true';

--- a/console/src/main/scripts/plugins/metrics/ts/inventoryExplorer.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/inventoryExplorer.ts
@@ -20,7 +20,7 @@
 
 module HawkularMetrics {
 
-  export class ExplorerController implements IRefreshable {
+  export class InventoryExplorerController implements IRefreshable {
     public title: string = 'Metrics Explorer';
     public pleaseWait = true;
     public resourceButtonEnabled = false;
@@ -71,7 +71,7 @@ module HawkularMetrics {
         this.charts = tmp;
         _.forEach(tmp, (metric: any) => {
           this.registerForAlerts(metric.feed, metric.resource);
-            this.$log.log('Found metric in storage: ' + metric.id);
+          this.$log.log('Found metric in storage: ' + metric.id);
         });
         if ($rootScope.currentPersona) {
           this.startTimeStamp = +moment().subtract(($routeParams.timeOffset || 3600000), 'milliseconds');
@@ -122,9 +122,11 @@ module HawkularMetrics {
 
     public getMetrics(resource) {
       this.pleaseWait = true;
+      this.selectedMetric = null;
+      this.buttonActive = false;
       this.HawkularInventory['MetricOfResourceUnderFeed']['get']({
           feedId: this.selectedFeed.id,
-          resourcePath: resource.id.replace(/\//g, '%2F')
+          resourcePath: resource.resourcePath.replace(/\/r;/g, '/').slice(1)
         },
         (metricList) => {
           this.metrics = metricList;
@@ -142,7 +144,7 @@ module HawkularMetrics {
     }
 
     private registerForAlerts(feed, resource) {
-      ExplorerController.stripLastCharactersFromResourceId(resource, 2);
+      InventoryExplorerController.stripLastCharactersFromResourceId(resource, 2);
       this.HawkularAlertRouterManager.registerForAlerts(
         feed.id + '/' + resource.id,
         'explorer',
@@ -177,9 +179,6 @@ module HawkularMetrics {
     }
 
     public showChart() {
-      this.$log.log('showChart');
-      this.$log.log(this.selectedMetric);
-
       // Only add if not empty and not yet in the array.
       if (this.selectedMetric != null && this.selectedMetric !== '' &&
            this.charts.indexOf(this.selectedMetric) === -1) {
@@ -277,6 +276,6 @@ module HawkularMetrics {
   //  });
   //}]);
 
-  _module.controller('ExplorerController', ExplorerController);
+  _module.controller('InventoryExplorerController', InventoryExplorerController);
 
 }

--- a/console/src/main/scripts/plugins/metrics/ts/viewController.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/viewController.ts
@@ -20,14 +20,13 @@
 
 module HawkularMetrics {
 
-  export class ViewController {
+  export class ViewContainerController {
     public viewClass: string;
     constructor(private $scope: any,
                 private $rootScope: any,
                 private $location: ng.ILocationService
     ) {
       const viewClasses = {
-        'app-list': 'container-fluid',
         'explorer/view': 'container-fluid'
       };
       Object.freeze(viewClasses);
@@ -48,11 +47,11 @@ module HawkularMetrics {
         }
       });
       if (!changed) {
-        this.viewClass = ViewController.defaultClass;
+        this.viewClass = ViewContainerController.defaultClass;
       }
     }
     public static get defaultClass(): string { return 'container'; }
   }
 
-  _module.controller('HawkularMetrics.ViewController', ViewController);
+  _module.controller('HawkularMetrics.ViewContainerController', ViewContainerController);
 }

--- a/console/src/main/webapp/index.html
+++ b/console/src/main/webapp/index.html
@@ -87,7 +87,7 @@
     </nav>
 
     <div ng-controller="HawtioNav.ViewController">
-      <div ng-controller="HawkularMetrics.ViewController as hkvc">
+      <div ng-controller="HawkularMetrics.ViewContainerController as hkvc">
         <div class="{{hkvc.viewClass}} screen-content" ng-include src="viewPartial"></div>
       </div>
     </div>


### PR DESCRIPTION
When recursive children are loaded slash needs to be hashed to %2F. When metrics are loaded for selected resource whole path from feed id should be taken, not only id.