### PR TITLE
HAWKULAR-1059 : Fix deployments select on refresh

### DIFF
--- a/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
+++ b/console/src/main/scripts/plugins/metrics/ts/app-details/appServerDeploymentsDetails.ts
@@ -157,7 +157,7 @@ module HawkularMetrics {
           if (res.id.indexOf(this.$routeParams.resourceId + '~/') === 0) {
             tmpResourceList.push(res);
             res.feedId = this.$routeParams.feedId;
-            res.selected = _.result(_.find(this.resourceList, { 'id': res.id }), 'selected') !== undefined;
+            res.selected = !!_.result(_.find(this.resourceList, { 'id': res.id }), 'selected');
             promises.push(this.HawkularMetric.AvailabilityMetricData(this.$rootScope.currentPersona.id).query({
               tenantId: tenantId,
               availabilityId: MetricsService.getMetricId('A', res.feedId, res.id,


### PR DESCRIPTION
When a periodic refresh occurred, the deployments table was selecting
all the items in the table. This fixes that behavior.