### PR TITLE
Update hawkular charts to 1.0.0

### DIFF
--- a/console/src/main/scripts/bower.json
+++ b/console/src/main/scripts/bower.json
@@ -24,7 +24,7 @@
     "angular-toastr": "1.6.0",
     "animate.css": "3.0.0",
     "ngInfiniteScroll": "1.2.1",
-    "hawkular-charts": "hawkular/hawkular-charts#9bfefa9",
+    "hawkular-charts": "1.0.0",
     "hawkular-ui-services": "0.9.3",
     "hawtio-core-navigation": "2.0.51",
     "hawtio-core": "2.0.30",

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
@@ -142,11 +142,11 @@
             <h2 class="card-pf-title"><!-- {{acd.description}} -->Metrics</h2>
           </div>
           <div class="card-pf-body">
-            <hawkular-sparkline-chart
+            <hk-metric-char
               data="acd.alertChartData"
               show-x-axis-values="true"
               show-y-axis-values="false">
-            </hawkular-sparkline-chart>
+            </hk-metric-char>
           </div>
         </div>
       </div>

--- a/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
+++ b/console/src/main/scripts/plugins/metrics/html/alerts-center-detail.html
@@ -142,11 +142,11 @@
             <h2 class="card-pf-title"><!-- {{acd.description}} -->Metrics</h2>
           </div>
           <div class="card-pf-body">
-            <hk-metric-char
+            <hk-metric-chart
               data="acd.alertChartData"
               show-x-axis-values="true"
               show-y-axis-values="false">
-            </hk-metric-char>
+            </hk-metric-chart>
           </div>
         </div>
       </div>

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-jvm.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-jvm.html
@@ -63,11 +63,11 @@
 
             <div class="hk-graph-container hk-graph-metrics">
               <!-- HINT: colors for the chart can be changed in the hawkular-charts.css -->
-              <hawkular-chart
+              <hk-metric-chart
                 multi-data="vm.chartHeapData"
                 chart-type="multiline"
                 y-axis-units="Usage (MB)">
-              </hawkular-chart>
+              </hk-metric-chart>
               <!-- Context Chart Begins here
               <div class="context-graph-container" ng-if="vm.contextChartHeapUsedData.length > 2">
                 <hawkular-context-chart
@@ -110,11 +110,11 @@
 
             <div class="hk-graph-container hk-graph-metrics">
               <!-- HINT: colors for the chart can be changed in the hawkular-charts.css -->
-              <hawkular-chart
+              <hk-metric-chart
                 multi-data="vm.chartNonHeapData"
                 chart-type="multiline"
                 y-axis-units="Usage (MB)">
-              </hawkular-chart>
+              </hk-metric-chart>
               <!-- Context Chart Begins here
               <div class="context-graph-container" ng-if="vm.contextChartNonHeapUsedData.length > 2">
                 <hawkular-context-chart
@@ -151,14 +151,14 @@
             <h2>GC Duration</h2>
 
             <div class="hk-graph-container hk-graph-metrics">
-              <hawkular-chart
+              <hk-metric-chart
                 data="vm.chartGCDurationData"
                 chart-type="histogram"
                 alert-value="{{vm.threshold}}"
                 use-zero-min-value="true"
                 hide-high-low-values="true"
                 y-axis-units="GC Duration (ms)">
-              </hawkular-chart>
+              </hk-metric-chart>
               <!-- Context Chart Begins here
               <div class="context-graph-container" ng-if="vm.contextChartGCDurationData.length > 2">
                 <hawkular-context-chart

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-platform.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-platform.html
@@ -68,8 +68,7 @@
             data="os.chartMemoryUsageData"
             chart-type="area"
             hide-high-low-values="false"
-            y-axis-units="Available (MB)"
-            chart-height="250">
+            y-axis-units="Available (MB)">
           </hk-metric-chart>
         </div>
       </div>

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-platform.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-platform.html
@@ -64,13 +64,13 @@
         <h2>Memory Usage</h2>
         <div class="hk-graph-container hk-graph-metrics" ng-if="os.resolvedMemoryData">
           <!-- HINT: colors for the chart can be changed in the hawkular-charts.css -->
-          <hawkular-chart
+          <hk-metric-chart
             data="os.chartMemoryUsageData"
             chart-type="area"
             hide-high-low-values="false"
             y-axis-units="Available (MB)"
             chart-height="250">
-          </hawkular-chart>
+          </hk-metric-chart>
         </div>
       </div>
 
@@ -79,13 +79,13 @@
         <!-- cpu summary usage over all cpus -->
         <div class="hk-graph-container hk-graph-metrics" ng-if="os.resolvedCPUData">
           <!-- HINT: colors for the chart can be changed in the hawkular-charts.css -->
-          <hawkular-chart
+          <hk-metric-chart
             data="os.chartCpuData"
             chart-type="rhqbar"
             hide-high-low-values="false"
             y-axis-units="Usage (%)"
             chart-height="250">
-          </hawkular-chart>
+          </hk-metric-chart>
         </div>
 
         <!-- mini charts per cpu -->
@@ -93,15 +93,17 @@
         <div class="panel panel-default hk-graph" ng-if="os.resolvedCPUData">
           <div class="row">
             <div class="hk-graph-container hk-graph-metrics col-xs-6"  ng-repeat="cpu in os.processorList">
-              <span ng-show="os.chartCpuDataMulti[cpu]">
+              <span ng-show="os.chartCpuDataMulti[cpu]" style="height: 100%;">
                 <!-- HINT: colors for the chart can be changed in the hawkular-charts.css -->
-                <hawkular-chart
-                  data="os.chartCpuDataMulti[cpu]"
-                  chart-type="rhqbar"
-                  hide-high-low-values="false"
-                  y-axis-units="Usage (%)"
-                  chart-height="150">
-                </hawkular-chart>
+                <div style="height: 100%">
+                    <hk-metric-chart
+                      data="os.chartCpuDataMulti[cpu]"
+                      chart-type="rhqbar"
+                      hide-high-low-values="false"
+                      y-axis-units="Usage (%)"
+                      chart-height="150">
+                    </hk-metric-chart>
+                  </div>
               </span>
               <span class="hk-data" ng-show="!os.chartCpuDataMulti[cpu]">Loading ...</span>
               <span class="hk-item">{{os.processorListNames[cpu]}}</span>
@@ -142,12 +144,12 @@
               <div ng-if="os.resolvedChartFileSystemData[fs.id]">
                 <h2>File System Usage</h2>
                 <div class="hk-graph-container hk-graph-metrics">
-                  <hawkular-chart
+                  <hk-metric-chart
                     multi-data="os.chartFileSystemData[fs.id]"
                     chart-type="multiline"
                     y-axis-units="Disk Space (MB)"
                     chart-height="250">
-                  </hawkular-chart>
+                  </hk-metric-chart>
                 </div>
                 <div class="row hk-legend hk-legend-inline text-left hk-legend-metrics">
                   <div class="col-md-12">
@@ -212,12 +214,12 @@
                 <div class="panel panel-default hk-graph" ng-if="os.resolvedChartFileSystemData[fs.id]">
                   <h2>File System Usage</h2>
                   <div class="hk-graph-container hk-graph-metrics">
-                    <hawkular-chart
+                    <hk-metric-chart
                       multi-data="os.chartFileSystemData[fs.id]"
                       chart-type="multiline"
                       y-axis-units="Disk Space (MB)"
                       chart-height="250">
-                    </hawkular-chart>
+                    </hk-metric-chart>
                   </div>
                   <div class="row hk-legend hk-legend-inline text-left hk-legend-metrics">
                     <div class="col-md-12">

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-transactions.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-transactions.html
@@ -55,26 +55,28 @@
             <h2 class="card-pf-title">
               Inflight Transactions
             </h2>
-            <div class="card-pf-body">
+            <div class="card-pf-body" style="height: 80px; width: 200px;">
               <p class="card-pf-utilization-details">
                 <span class="card-pf-utilization-card-details-count">{{vm.inflightTx.max}}</span>
               </p>
-              <hawkular-sparkline-chart data="vm.chartTxInflightData" show-x-axis-values="false"
-                                        show-y-axis-values="false"></hawkular-sparkline-chart>
+              <hk-metric-chart data="vm.chartTxInflightData"
+                               show-x-axis-values="false"
+                               show-y-axis-values="false">
+              </hk-metric-chart>
               <!--<p class="hk-card-interval">Last Hour</p>--> <!-- TODO: Show interval ? -->
             </div>
           </div>
         </div>
 
         <div class="col-sm-9">
-          <div class="card-pf hk-graph">
+          <div class="card-pf hk-graph hk-graph-metrics">
             <h2>Transactions <!-- span>(10 Jun 2015, 12:15 - 13:15)</span TODO: Show interval ? --></h2>
 
-            <hawkular-chart
+            <hk-metric-chart
               multi-data="vm.chartTxData"
               chart-type="multiline"
               y-axis-units="Count (#)">
-            </hawkular-chart>
+            </hk-metric-chart>
 
             <div class="row hk-legend text-left">
               <div class="hk-graphselector hk-blue col-md-4 col-sm-6">

--- a/console/src/main/scripts/plugins/metrics/html/app-details/detail-web.html
+++ b/console/src/main/scripts/plugins/metrics/html/app-details/detail-web.html
@@ -55,12 +55,12 @@
             <h2>Web Sessions</h2>
             <div class="hk-graph-container hk-graph-metrics">
               <!-- HINT: colors for the chart can be changed in the hawkular-charts.css -->
-              <hawkular-chart
+              <hk-metric-chart
                 multi-data="vm.chartWebSessionData"
                 chart-type="multiline"
                 y-axis-units="Count (#)"
                 chart-height="250">
-              </hawkular-chart>
+              </hk-metric-chart>
               <!--
               <div class="context-graph-container" ng-if="vm.contextChartActiveWebSessionData.length > 2">
                 <hawkular-context-chart

--- a/console/src/main/scripts/plugins/metrics/html/directives/datasources/detail.html
+++ b/console/src/main/scripts/plugins/metrics/html/directives/datasources/detail.html
@@ -20,10 +20,10 @@
       <div class="panel panel-default hk-graph" ng-if="vm.resolvedAvailData">
         <h2>Availability</h2>
         <div class="hk-graph-container hk-graph-metrics">
-          <hawkular-chart multi-data="vm.chartAvailData"
+          <hk-metric-chart multi-data="vm.chartAvailData"
                           chart-type="multiline" y-axis-units="Availability (#)"
                           chart-height="250">
-          </hawkular-chart>
+          </hk-metric-chart>
         </div>
         <div class="row hk-legend hk-legend-inline text-left hk-legend-metrics">
           <div class="col-md-12">
@@ -53,11 +53,11 @@
       <div class="panel panel-default hk-graph" ng-if="vm.resolvedRespData">
         <h2>Responsiveness</h2>
         <div class="hk-graph-container hk-graph-metrics">
-          <hawkular-chart multi-data="vm.chartRespData"
+          <hk-metric-chart multi-data="vm.chartRespData"
                           chart-type="multiline"
                           y-axis-units="Responsiveness (ms)"
                           chart-height="250">
-          </hawkular-chart>
+          </hk-metric-chart>
         </div>
         <div class="row hk-legend hk-legend-inline text-left hk-legend-metrics">
           <div class="col-md-12">

--- a/console/src/main/scripts/plugins/metrics/html/directives/overview/status-overview-item.html
+++ b/console/src/main/scripts/plugins/metrics/html/directives/overview/status-overview-item.html
@@ -7,7 +7,7 @@
       <span class="card-pf-utilization-card-details-line-2">{{metricInfo}}</span>
     </span>
   </p>
-  <div class="hk-info">
-    <ng-transclude></ng-transclude>
+  <div class="hk-info" style="height: 150px;">
+    <ng-transclude style="height: 150px; width: 300px"></ng-transclude>
   </div>
 </div>

--- a/console/src/main/scripts/plugins/metrics/html/directives/overview/status-overview.html
+++ b/console/src/main/scripts/plugins/metrics/html/directives/overview/status-overview.html
@@ -12,20 +12,21 @@
         <hk-status-overview-item metric-title="Alerts"
                                  metric-count="alertInfo.alertCount"
                                  metric-info="Open Alerts">
-          <hawkular-sparkline-chart data="alertInfo.graphData"
+          <hk-metric-chart data="alertInfo.graphData"
                                     show-x-axis-values="true"
                                     show-y-axis-values="true">
-          </hawkular-sparkline-chart>
+          </hk-metric-chart>
         </hk-status-overview-item>
       </div>
       <div class="col-sm-6 hk-dashboard-block">
         <hk-status-overview-item metric-title="JVM Heap Usage"
                                  metric-count="overviewInfo.heapUsage.last / 1024 / 1024 | number : 0"
                                  metric-info="JVM Heap Usage">
-          <hawkular-sparkline-chart data="overviewInfo.heapUsage.graph"
+          <hk-metric-chart data="overviewInfo.heapUsage.graph"
                                     show-x-axis-values="true"
-                                    show-y-axis-values="true">
-          </hawkular-sparkline-chart>
+                                    show-y-axis-values="true"
+                                    chart-type="area">
+          </hk-metric-chart>
         </hk-status-overview-item>
       </div>
       <div ng-repeat="datasource in datasourceInfo track by $index" class="col-sm-6 hk-dashboard-block">
@@ -71,11 +72,11 @@
         <hk-status-overview-item metric-title="Web Sessions"
                                  metric-count="overviewInfo.activeWebSessions.last"
                                  metric-info="active sessions">
-          <div ng-if="overviewInfo && overviewInfo.activeWebSessions">
-            <hawkular-sparkline-chart data="overviewInfo.activeWebSessions.graph"
+          <div ng-if="overviewInfo && overviewInfo.activeWebSessions" style="height: 150px; width: 300px">
+            <hk-metric-chart data="overviewInfo.activeWebSessions.graph"
                                       show-x-axis-values="true"
                                       show-y-axis-values="true">
-            </hawkular-sparkline-chart>
+            </hk-metric-chart>
           </div>
         </hk-status-overview-item>
       </div>

--- a/console/src/main/scripts/plugins/metrics/html/directives/url-list/item.html
+++ b/console/src/main/scripts/plugins/metrics/html/directives/url-list/item.html
@@ -15,11 +15,11 @@
         <span class="spinner spinner-inline" ng-hide="vm.resource.responseTime.length > 0" popover="Your data is being collected. You should see something in a few seconds." popover-trigger="mouseenter" popover-placement="bottom"></span>
       </div>
       <div class="chart-pf-sparkline {{vm.resource.isUp?'':'c3-danger'}}">
-        <hawkular-sparkline-chart
+        <hk-metric-chart
           data="vm.resource.graphResponseTime"
           show-x-axis-values="false"
           show-y-axis-values="false">
-        </hawkular-sparkline-chart>
+        </hk-metric-chart>
       </div>
       <div class="hk-tile-info">
         <a href="{{vm.getResponseTimeUrl(vm.resource.id)}}">

--- a/console/src/main/scripts/plugins/metrics/html/explorer.html
+++ b/console/src/main/scripts/plugins/metrics/html/explorer.html
@@ -21,24 +21,26 @@
       </div>
       <div class="row row-cards-pf">
         <div class="col-xs-12">
-          <div ng-repeat="chart in exc.charts" class="card-pf hk-graph">
+          <div ng-repeat="chart in exc.charts" class="card-pf hk-graph" style="height: 380px">
             <h2>{{chart.name}}</h2>
             <a href="" ng-click="exc.removeChart(chart)" title="Remove this chart">
               <span class="pull-right"><i class="fa fa-trash-o"></i></span>
             </a>
-            <hawkular-chart
-              ng-if="exc.chartType[chart.id] !=='AVAILABILITY'"
-              data="exc.chartData[chart.id]"
-              chart-type="line"
-              hide-high-low-values="false"
-              use-zero-min-value="false"
-              y-axis-units="{{chart.type.unit}}"
-              chart-height="250">
-            </hawkular-chart>
-            <availability-chart ng-if="exc.chartType[chart.id] ==='AVAILABILITY'"
-                                data="exc.chartData[chart.id]"
-                                chart-height="250">
-            </availability-chart>
+            <div style="height: 300px">
+                <hk-metric-chart
+                  ng-if="exc.chartType[chart.id] !=='AVAILABILITY'"
+                  data="exc.chartData[chart.id]"
+                  chart-type="line"
+                  hide-high-low-values="false"
+                  use-zero-min-value="false"
+                  y-axis-units="{{chart.type.unit}}"
+                  chart-height="250">
+                </hk-metric-chart>
+                <hk-availability-chart ng-if="exc.chartType[chart.id] ==='AVAILABILITY'"
+                                    data="exc.chartData[chart.id]"
+                                    chart-height="250">
+                </hk-availability-chart>
+              </div>
           </div>
         </div>
       </div>

--- a/console/src/main/scripts/plugins/metrics/html/url-availability.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-availability.html
@@ -87,11 +87,11 @@
           <h2>Availability</h2>
 
           <div class="hk-graph-container hk-graph-availability">
-            <availability-chart
+            <hk-availability-chart
               start-timestamp="{{vm.startTimeStamp}}"
               end-timestamp="{{vm.endTimeStamp}}"
               data="vm.availabilityDataPoints">
-            </availability-chart>
+            </hk-availability-chart>
           </div>
           <div class="hk-legend text-left hk-legend-availability">
             <span><span class="hk-legend-square hk-green"></span>Available</span>

--- a/console/src/main/scripts/plugins/metrics/html/url-response-time.html
+++ b/console/src/main/scripts/plugins/metrics/html/url-response-time.html
@@ -76,14 +76,14 @@
 
           <div class="hk-graph-container hk-graph-metrics">
             <!-- HINT: colors for the chart can be changed in the hawkular-charts.css -->
-            <hawkular-chart
+            <hk-metric-chart
               data="vm.chartData.dataPoints"
               chart-type="line"
               alert-value="{{vm.threshold}}"
               use-zero-min-value="true"
               y-axis-units="Response Time (ms)"
               chart-height="250">
-            </hawkular-chart>
+            </hk-metric-chart>
           </div>
 
           <div class="hk-legend text-left hk-legend-metrics" ng-show="vm.chartData.dataPoints.length">

--- a/console/src/main/scripts/plugins/metrics/less/metrics.less
+++ b/console/src/main/scripts/plugins/metrics/less/metrics.less
@@ -459,7 +459,7 @@ a:hover {
     }
 
     &.hk-graph-metrics {
-
+      height: 300px;
       svg {
         margin-bottom: -13px;
         margin-left: -5px;


### PR DESCRIPTION
Update hawkular charts to 1.0.0

Some screenshots: https://drive.google.com/open?id=0BxM9OWSBhvYoQ01lb1pjQVM5MnM
Note that alternatives to ``sparkline`` charts reserve some space on the left for y axis label.

@mtho11 could you please review?